### PR TITLE
Fix: missmatch between minReq and EndTrigger

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -9,6 +9,7 @@ const NEW_ROUND_DELAY = 10 // seconds
 const MAX_UP_SPEED = 12 // m/s allowed upward speed before considering teleport
 const HEIGHT_TOLERANCE = 0.5 // m of extra leeway per sample
 const HARD_MAX_DELTA = 20 // m allowed upward jump regardless of sample time
+const END_TRIGGER_OFFSET = 11
 
 export function server() {
   console.log('[Server] Tower of Madness starting...')
@@ -227,7 +228,7 @@ function setupMessageHandlers(gameState: GameState) {
     const liveKitPlayer = getPlayer({ userId: player.address })
     const currentHeight = liveKitPlayer?.position?.y || player.maxHeight
     const towerConfig = gameState.getTowerConfig()
-    const minFinishHeight = towerConfig ? towerConfig.totalHeight - 11 : 80 // Must be near the top (within 5m)
+    const minFinishHeight = towerConfig ? towerConfig.totalHeight - END_TRIGGER_OFFSET : 80
 
     console.log(`[Server] Finish attempt: height=${currentHeight.toFixed(1)}m, towerHeight=${towerConfig?.totalHeight.toFixed(1)}m, minRequired=${minFinishHeight.toFixed(1)}m`)
 


### PR DESCRIPTION
The minimum finish height required by the server was
`minFinishHeight = towerConfig ? towerConfig.totalHeight - 5`

The difference between the trigger position and towerConfig.totalHeight is 10.8 m, which is why the server was rejecting the finish attempt.

The required height has now been updated to:
`minFinishHeight = towerConfig ? towerConfig.totalHeight - 11.`

Closes #46 
Closes #47
Closes #48 