### PR TITLE
fix: time-sync-bug

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -11,6 +11,7 @@ const HEIGHT_TOLERANCE = 0.5 // m of extra leeway per sample
 const HARD_MAX_DELTA = 20 // m allowed upward jump regardless of sample time
 const TELEPORT_BASE = { x: 45, y: 2.5, z: 59 }
 const END_TRIGGER_OFFSET = 11
+const ROUND_TIMER_CHECK_INTERVAL = 0.25 // seconds
 
 export function server() {
   console.log('[Server] Tower of Madness starting...')
@@ -28,7 +29,7 @@ export function server() {
 
   engine.addSystem((dt: number) => {
     lastUpdate += dt
-    if (lastUpdate < 1) return
+    if (lastUpdate < ROUND_TIMER_CHECK_INTERVAL) return
     lastUpdate = 0
 
     const phase = gameState.getPhase()

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -19,7 +19,7 @@ export const RoundStateComponent = engine.defineComponent('tower:RoundState', {
   phase: Schemas.EnumString<RoundPhase>(RoundPhase, RoundPhase.ACTIVE),
   baseTimer: Schemas.Number,              // Total round time (420 seconds)
   speedMultiplier: Schemas.Number,
-  lastSpeedChangeTime: Schemas.Number,    // Server timestamp when multiplier changed
+  lastSpeedChangeTime: Schemas.Int64,     // Server timestamp when multiplier changed
   remainingAtSpeedChange: Schemas.Number, // Remaining seconds at that moment
   finisherCount: Schemas.Number
 })


### PR DESCRIPTION
in this PR:
Fix the time sync bug. Change Date.now() from float to int64.
closes #64 

