### PR TITLE
fix: ui keys

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ import { Vector3 } from '@dcl/sdk/math'
 import { isServer, isStateSyncronized } from '@dcl/sdk/network'
 import { movePlayerTo } from '~system/RestrictedActions'
 import { EntityNames } from '../assets/scene/entity-names'
-import { setupUi } from './ui'
+import { setupUi, toggleDebugConsole } from './ui'
 import { setupWorldLeaderboard } from './Leaderboard'
 import { setupWorldPointLeaderboard } from './PointLeaderboard'
 import { server } from './server/server'
@@ -413,6 +413,16 @@ export async function main() {
     },
     undefined,
     'snapshot-player-enter-system'
+  )
+
+  engine.addSystem(
+    () => {
+      if (inputSystem.isTriggered(InputAction.IA_ACTION_3, PointerEventType.PET_DOWN)) {
+        toggleDebugConsole()
+      }
+    },
+    undefined,
+    'debug-console-toggle-system'
   )
 
   setupWorldLeaderboard(() => leaderboard, () => weeklyLeaderboard)

--- a/src/snapshots.ts
+++ b/src/snapshots.ts
@@ -34,10 +34,6 @@ export async function requestPlayerSnapshot(wallet: string, displayName?: string
     }
     snapshotByWallet.set(normalized, entry)
     snapshots.unshift(entry)
-
-    if (snapshots.length > 12) {
-      snapshots.length = 12
-    }
   } else if (displayName && entry.displayName.startsWith('0x')) {
     entry.displayName = displayName
   }
@@ -73,7 +69,7 @@ async function getPlayerSnapshot(wallet: string): Promise<string | null> {
   const rawFace = snapshots?.face ?? null
   const normalizedFace256 = normalizeSnapshotUrl(rawFace256)
   const normalizedFace = normalizeSnapshotUrl(rawFace)
-  const chosen = normalizedFace256 ?? normalizedFace ?? DEFAULT_AVATAR_IMAGE
+  const chosen = normalizedFace ?? normalizedFace256 ?? DEFAULT_AVATAR_IMAGE
   const chosenCid = chosen ? extractCidFromUrl(chosen) : null
 
   console.log(

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -1,4 +1,4 @@
-import ReactEcs, { UiEntity, ReactEcsRenderer } from "@dcl/sdk/react-ecs"
+import ReactEcs, { UiEntity, ReactEcsRenderer, Input, Button } from "@dcl/sdk/react-ecs"
 import { Color4 } from "@dcl/sdk/math"
 import { engine, UiCanvasInformation, PlayerIdentityData } from "@dcl/sdk/ecs"
 
@@ -48,7 +48,9 @@ import {
   formatTime,
   getTowerChunksFromEntities
 } from "./multiplayer"
-import { getSnapshots } from "./snapshots"
+import {
+  getSnapshots
+} from "./snapshots"
 import { OutlinedText, OUTLINE_OFFSETS_16, OUTLINE_OFFSETS_8 } from "./outlinedTextComponent"
 
 export function setupUi() {
@@ -76,6 +78,49 @@ const CONNECT_FLOOR_STEP_SECONDS = 0.16
 const CONNECT_MIN_VISIBLE_MS = CONNECT_FLOOR_COUNT * CONNECT_FLOOR_STEP_SECONDS * 1000
 let connectUiCycleStartedAtMs = 0
 let connectUiMinVisibleUntilMs = 0
+
+type DebugConsoleMode = 'console' | 'snapshot'
+
+let debugConsoleVisible = false
+let debugConsoleMode: DebugConsoleMode = 'console'
+let debugConsoleInput = ''
+let debugConsoleFeedback = 'Enter password and click Open'
+
+export function toggleDebugConsole() {
+  debugConsoleVisible = !debugConsoleVisible
+
+  if (!debugConsoleVisible) {
+    debugConsoleMode = 'console'
+    debugConsoleInput = ''
+    debugConsoleFeedback = 'Enter password and click Open'
+  }
+}
+
+export function closeDebugConsole() {
+  debugConsoleVisible = false
+  debugConsoleMode = 'console'
+  debugConsoleInput = ''
+  debugConsoleFeedback = 'Enter password and click Open'
+}
+
+function runDebugConsoleCommand(rawValue: string) {
+  const command = rawValue.trim().toLowerCase()
+  debugConsoleInput = rawValue
+
+  if (!command) {
+    debugConsoleFeedback = 'Enter password and click Open'
+    return
+  }
+
+  if (command === 'snapshot') {
+    debugConsoleMode = 'snapshot'
+    debugConsoleFeedback = 'Showing snapshot debug for connected players'
+    return
+  }
+
+  debugConsoleMode = 'console'
+  debugConsoleFeedback = `Unknown command: ${command}`
+}
 
 function getTrophyUvsByRank(index: number): number[] {
   // UV order: bottom-left, top-left, top-right, bottom-right
@@ -144,6 +189,8 @@ const TowerProgressBar = () => {
     const clampedHeight = Math.max(0, Math.min(height, totalHeight))
     return (clampedHeight / totalHeight) * BAR_WIDTH
   }
+
+  const displayedPlayers = getLocalPlayerHeights(false)
 
   return (
     <UiEntity
@@ -219,7 +266,7 @@ const TowerProgressBar = () => {
       />
 
       {/* Player indicators inside bar */}
-      {getLocalPlayerHeights(false).slice(0, 12).map((player, index) => {
+      {displayedPlayers.map((player, index) => {
         const xPos = getPlayerXPosition(player.height)
         const wallet = player.address?.toLowerCase() ?? ''
         const snapshotUrl = snapshotByWallet.get(wallet) ?? null
@@ -227,7 +274,7 @@ const TowerProgressBar = () => {
 
         return (
           <UiEntity
-            key={`player-${index}`}
+            key={wallet ? `player-${wallet}` : `player-index-${index}`}
             uiTransform={{
               width: PLAYER_MARKER_SIZE,
               height: PLAYER_MARKER_SIZE,
@@ -255,7 +302,7 @@ const TowerProgressBar = () => {
                       texture: { src: snapshotUrl },
                       textureMode: 'stretch'
                     }
-                  : { color: Color4.create(0.2, 0.2, 0.2, 0.9) }
+                  : { color: Color4.create(0, 0, 0, 0) }
               }
             />
 
@@ -289,6 +336,279 @@ const TowerProgressBar = () => {
           </UiEntity>
         )
       })}
+    </UiEntity>
+  )
+}
+
+function getSnapshotStatusColor(status: 'loading' | 'ok' | 'missing' | 'error'): Color4 {
+  if (status === 'ok') return Color4.create(0.5, 1, 0.5, 1)
+  if (status === 'loading') return Color4.create(1, 0.85, 0.25, 1)
+  if (status === 'missing') return Color4.create(0.8, 0.65, 1, 1)
+  return Color4.create(1, 0.45, 0.45, 1)
+}
+
+const DebugConsoleOverlay = () => {
+  if (!debugConsoleVisible) return null
+
+  const s = getScaleUIFactor()
+  const uiCanvasInfo = UiCanvasInformation.getOrNull(engine.RootEntity)
+  const screenWidth = uiCanvasInfo?.width ?? 1920 * s
+  const screenHeight = uiCanvasInfo?.height ?? 1080 * s
+  const connectedPlayers = getLocalPlayerHeights(false).slice(0, 20)
+  const snapshots = getSnapshots()
+  const snapshotByWallet = new Map(
+    snapshots.map((entry) => [entry.wallet.toLowerCase(), entry])
+  )
+  const showingSnapshots = debugConsoleMode === 'snapshot'
+  const panelWidth = 920 * s
+  const panelHeight = showingSnapshots ? 760 * s : 210 * s
+  const panelLeft = Math.max(20 * s, (screenWidth - panelWidth) / 2)
+  const panelTop = Math.max(24 * s, (screenHeight - panelHeight) / 2)
+  const columns = connectedPlayers.length > 10 ? 2 : 1
+  const rowsPerColumn = Math.max(1, Math.ceil(connectedPlayers.length / columns))
+  const columnGap = 16 * s
+  const columnWidth = (panelWidth - 32 * s - (columns - 1) * columnGap) / columns
+  const rowHeight = 62 * s
+
+  return (
+    <UiEntity
+      uiTransform={{
+        width: '100%',
+        height: '100%',
+        positionType: 'absolute',
+        position: { left: 0, top: 0 }
+      }}
+      uiBackground={{
+        color: Color4.create(0, 0, 0, 0.72)
+      }}
+    >
+      <UiEntity
+        uiTransform={{
+          width: panelWidth,
+          height: panelHeight,
+          positionType: 'absolute',
+          position: { left: panelLeft, top: panelTop }
+        }}
+        uiBackground={{
+          color: Color4.create(0.04, 0.04, 0.07, 0.97)
+        }}
+      >
+        <UiEntity
+          uiTransform={{
+            width: panelWidth,
+            height: 48 * s,
+            positionType: 'absolute',
+            position: { left: 0, top: 0 }
+          }}
+          uiBackground={{
+            color: Color4.create(0.08, 0.08, 0.12, 1)
+          }}
+        >
+          <UiEntity
+            uiTransform={{
+              width: panelWidth - 84 * s,
+              height: 48 * s,
+              positionType: 'absolute',
+              position: { left: 16 * s, top: 0 }
+            }}
+            uiText={{
+              value: 'DEBUG CONSOLE',
+              fontSize: 22 * s,
+              color: Color4.White(),
+              textAlign: 'middle-left'
+            }}
+          />
+          <Button
+            value="X"
+            variant="secondary"
+            fontSize={16 * s}
+            uiTransform={{
+              width: 44 * s,
+              height: 32 * s,
+              positionType: 'absolute',
+              position: { right: 12 * s, top: 8 * s }
+            }}
+            onMouseDown={() => closeDebugConsole()}
+          />
+        </UiEntity>
+
+        <UiEntity
+          uiTransform={{
+            width: panelWidth - 48 * s,
+            height: 52 * s,
+            positionType: 'absolute',
+            position: { left: 24 * s, top: 72 * s },
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'center'
+          }}
+        >
+          <Input
+            placeholder='Enter password'
+            placeholderColor={Color4.create(0.45, 0.45, 0.5, 1)}
+            color={Color4.Black()}
+            fontSize={18 * s}
+            uiTransform={{
+              width: 360 * s,
+              height: 42 * s
+            }}
+            onChange={(value) => {
+              debugConsoleInput = value
+            }}
+          />
+          <Button
+            value="Open"
+            variant="secondary"
+            fontSize={16 * s}
+            uiTransform={{
+              width: 110 * s,
+              height: 42 * s,
+              margin: { left: 12 * s }
+            }}
+            onMouseDown={() => runDebugConsoleCommand(debugConsoleInput)}
+          />
+        </UiEntity>
+
+        <UiEntity
+          uiTransform={{
+            width: panelWidth - 48 * s,
+            height: 22 * s,
+            positionType: 'absolute',
+            position: { left: 24 * s, top: 130 * s }
+          }}
+          uiText={{
+            value: debugConsoleFeedback,
+            fontSize: 14 * s,
+            color: Color4.create(0.82, 0.85, 0.92, 1),
+            textAlign: 'middle-center'
+          }}
+        />
+
+        {showingSnapshots && (
+          <UiEntity
+            uiTransform={{
+              width: panelWidth - 32 * s,
+              height: panelHeight - 178 * s,
+              positionType: 'absolute',
+              position: { left: 16 * s, top: 162 * s }
+            }}
+            uiBackground={{
+              color: Color4.create(0.08, 0.08, 0.12, 0.96)
+            }}
+          >
+            <UiEntity
+              uiTransform={{
+                width: panelWidth - 48 * s,
+                height: 28 * s,
+                positionType: 'absolute',
+                position: { left: 16 * s, top: 8 * s }
+              }}
+              uiText={{
+                value: `Connected players: ${connectedPlayers.length}/20`,
+                fontSize: 14 * s,
+                color: Color4.White(),
+                textAlign: 'middle-left'
+              }}
+            />
+
+            {connectedPlayers.map((player, index) => {
+              const wallet = player.address.toLowerCase()
+              const snapshotEntry = snapshotByWallet.get(wallet)
+              const snapshotUrl = snapshotEntry?.snapshotUrl ?? null
+              const status = snapshotEntry?.status ?? 'loading'
+              const column = Math.floor(index / rowsPerColumn)
+              const row = index % rowsPerColumn
+              const rowLeft = 12 * s + column * (columnWidth + columnGap)
+              const rowTop = 42 * s + row * rowHeight
+
+              return (
+                <UiEntity
+                  key={`debug-console-snapshot-${wallet}`}
+                  uiTransform={{
+                    width: columnWidth,
+                    height: 54 * s,
+                    positionType: 'absolute',
+                    position: { left: rowLeft, top: rowTop }
+                  }}
+                  uiBackground={{
+                    color: Color4.create(0.12, 0.12, 0.17, 0.92)
+                  }}
+                >
+                  <UiEntity
+                    uiTransform={{
+                      width: 46 * s,
+                      height: 46 * s,
+                      positionType: 'absolute',
+                      position: { left: 4 * s, top: 4 * s }
+                    }}
+                    uiBackground={
+                      snapshotUrl
+                        ? {
+                            color: Color4.White(),
+                            texture: { src: snapshotUrl },
+                            textureMode: 'stretch'
+                          }
+                        : {
+                            color:
+                              status === 'error'
+                                ? Color4.create(0.85, 0.2, 0.2, 1)
+                                : status === 'missing'
+                                  ? Color4.create(0.6, 0.4, 0.95, 1)
+                                  : Color4.create(0.9, 0.75, 0.2, 1)
+                          }
+                    }
+                  />
+
+                  <UiEntity
+                    uiTransform={{
+                      width: columnWidth - 62 * s,
+                      height: 18 * s,
+                      positionType: 'absolute',
+                      position: { left: 58 * s, top: 4 * s }
+                    }}
+                    uiText={{
+                      value: `${index + 1}. ${player.displayName}`,
+                      fontSize: 11 * s,
+                      color: Color4.White(),
+                      textAlign: 'middle-left'
+                    }}
+                  />
+
+                  <UiEntity
+                    uiTransform={{
+                      width: columnWidth - 62 * s,
+                      height: 16 * s,
+                      positionType: 'absolute',
+                      position: { left: 58 * s, top: 22 * s }
+                    }}
+                    uiText={{
+                      value: wallet,
+                      fontSize: 9 * s,
+                      color: Color4.create(0.75, 0.78, 0.85, 1),
+                      textAlign: 'middle-left'
+                    }}
+                  />
+
+                  <UiEntity
+                    uiTransform={{
+                      width: columnWidth - 62 * s,
+                      height: 14 * s,
+                      positionType: 'absolute',
+                      position: { left: 58 * s, top: 38 * s }
+                    }}
+                    uiText={{
+                      value: `status: ${status}`,
+                      fontSize: 9 * s,
+                      color: getSnapshotStatusColor(status),
+                      textAlign: 'middle-left'
+                    }}
+                  />
+                </UiEntity>
+              )
+            })}
+          </UiEntity>
+        )}
+      </UiEntity>
     </UiEntity>
   )
 }
@@ -1337,6 +1657,7 @@ const GameUI = () => {
       */}
       {/* Tower Progress Bar - Top Center */}
       <TowerProgressBar />
+      <DebugConsoleOverlay />
       {/* START MESSAGE - Below Progress Bar Left */}
       {showStartMessage && (
         <UiEntity


### PR DESCRIPTION
This change removes all temporary snapshot stress/debug UI and restores the scene to normal production behavior, while keeping the main suspected fix for the avatar progress bar issue.

What was kept:

- The tower progress bar now uses a stable React ECS key per player wallet instead of array index.
- This matters because the player list is reordered frequently by height; using index keys could cause UI node reuse across different players, which is a strong candidate for the “avatar turns black after more players join” bug.

What was removed:

- Snapshot stress test wallets
- Forced snapshot preload for debug wallets
- Snapshot catalog/debug overlay experiments
- Temporary visual stress harnesses for overlapping/moving avatar thumbnails

 What was added:

- A hidden debug console toggled with keyboard 1
- A centered overlay titled DEBUG CONSOLE
- A close X button
- A password-style input with placeholder Enter password
- A mouse-click Open button
- If the user enters snapshot, it opens a snapshot diagnostics panel for up to 20 currently connected real players, showing avatar image, name, wallet, and snapshot status

Current diagnosis:

- Black squares are the UI fallback state for “no usable image on this slot”
- During investigation, we confirmed there are at least two possible contributors:
1. some snapshot URLs/assets do not render reliably in UI even when resolved
2. unstable UI identity from index-based keys was also a real risk when player ordering changed dynamically

This PR keeps the safe structural fix (key by wallet) and removes the experimental debug harness from the main scene flow

Closes #77 