### PR TITLE
refactor: use assets/chunks as the single source of truth for tower chunks

### DIFF
--- a/src/multiplayer.ts
+++ b/src/multiplayer.ts
@@ -22,6 +22,7 @@ import {
   WinnerEntry,
   TowerConfig
 } from './shared/schemas'
+import { CHUNK_START_ID, getChunkIdFromAssetPath } from './shared/chunks'
 import { getServerTime, isTimeSyncReady, getTimeSyncOffset } from './shared/timeSync'
 
 // Re-export types for compatibility
@@ -213,20 +214,20 @@ export function getTowerChunksFromEntities(): string[] {
     const visibility = VisibilityComponent.get(entity)
     if (!visibility.visible) continue
 
-    // Derive chunkId from GltfContainer.src (e.g., "assets/chunks/Chunk01.glb" -> "Chunk01")
+    // Derive chunkId from any shared chunk asset path (e.g., "assets/chunks/Chunk01.glb" -> "Chunk01")
     const gltf = GltfContainer.get(entity)
-    const match = gltf.src.match(/assets\/chunks\/(\w+)\.glb/)
-    if (!match) continue
+    const chunkId = getChunkIdFromAssetPath(gltf.src)
+    if (!chunkId) continue
 
     const transform = Transform.get(entity)
-    chunks.push({ chunkId: match[1], y: transform.position.y })
+    chunks.push({ chunkId, y: transform.position.y })
   }
 
   // Sort by Y position (lowest first) and return chunk IDs
   chunks.sort((a, b) => a.y - b.y)
 
   // Add ChunkStart at the beginning (it's a static entity, not in the pool)
-  return ['ChunkStart', ...chunks.map((c) => c.chunkId)]
+  return [CHUNK_START_ID, ...chunks.map((c) => c.chunkId)]
 }
 
 export function getTowerConfig(): TowerConfig | null {

--- a/src/server/gameState.ts
+++ b/src/server/gameState.ts
@@ -14,6 +14,14 @@ import {
   TriggerEndComponent,
   RoundPhase
 } from '../shared/schemas'
+import {
+  CHUNK_END_ID,
+  CHUNK_START_ID,
+  MAX_TOWER_MIDDLE_CHUNKS,
+  MIDDLE_CHUNK_IDS,
+  MIN_TOWER_MIDDLE_CHUNKS,
+  getChunkAssetPath
+} from '../shared/chunks'
 import { PodiumAvatarsServer } from './podiumAvatarsServer'
 
 // Helper to protect synced components on an entity
@@ -30,11 +38,6 @@ function protectServerEntity(entity: Entity, components: ComponentWithValidation
 }
 
 // Constants
-const CHUNK_OPTIONS = Array.from({ length: 10 }, (_, i) =>
-  `Chunk${String(i + 1).padStart(2, '0')}`
-)
-const MIN_CHUNKS = 3
-const MAX_CHUNKS = 8
 const BASE_TIMER = 420 // 7 minutes
 const CHUNK_HEIGHT = 10.821
 const TOWER_X = 40
@@ -260,8 +263,8 @@ export class GameState {
       TriggerEndComponent.componentId
     ])
 
-    // Create entity pool for tower chunks (MAX_CHUNKS + 1 for ChunkEnd)
-    for (let i = 0; i < MAX_CHUNKS + 1; i++) {
+    // Create entity pool for tower chunks (max middle chunks + 1 for ChunkEnd)
+    for (let i = 0; i < MAX_TOWER_MIDDLE_CHUNKS + 1; i++) {
       const entity = engine.addEntity()
       Transform.create(entity, {
         position: Vector3.create(TOWER_X, 0, TOWER_Z),
@@ -437,7 +440,7 @@ export class GameState {
       transform.rotation = Quaternion.fromEulerDegrees(0, rotationY, 0)
       transform.scale = Vector3.One()
 
-      GltfContainer.getMutable(entity).src = `assets/chunks/${chunkIds[i]}.glb`
+      GltfContainer.getMutable(entity).src = getChunkAssetPath(chunkIds[i])
       VisibilityComponent.getMutable(entity).visible = true
 
       this.towerEntities.push(entity)
@@ -453,7 +456,7 @@ export class GameState {
     endTransform.rotation = Quaternion.fromEulerDegrees(0, endRotationY, 0)
     endTransform.scale = Vector3.One()
 
-    GltfContainer.getMutable(endEntity).src = 'assets/custom/chunkend01.glb/ChunkEnd.glb'
+    GltfContainer.getMutable(endEntity).src = getChunkAssetPath(CHUNK_END_ID)
     VisibilityComponent.getMutable(endEntity).visible = true
     // Ensure only the current end entity has the ChunkEnd tag
     for (const entity of this.towerEntityPool) {
@@ -481,7 +484,7 @@ export class GameState {
     }
 
     // Update tower config for UI (include ChunkStart at the beginning)
-    const allChunks = ['ChunkStart', ...chunkIds, 'ChunkEnd']
+    const allChunks = [CHUNK_START_ID, ...chunkIds, CHUNK_END_ID]
     const totalHeight = CHUNK_HEIGHT * (chunkIds.length + 2) // +1 for ChunkEnd, +1 for base
     const towerConfig = TowerConfigComponent.getMutable(this.towerConfigEntity)
     towerConfig.chunkIds = allChunks
@@ -498,9 +501,11 @@ export class GameState {
     this.destroyTower()
 
     // Generate random chunks
-    const numChunks = Math.floor(Math.random() * (MAX_CHUNKS - MIN_CHUNKS + 1)) + MIN_CHUNKS
+    const numChunks =
+      Math.floor(Math.random() * (MAX_TOWER_MIDDLE_CHUNKS - MIN_TOWER_MIDDLE_CHUNKS + 1)) +
+      MIN_TOWER_MIDDLE_CHUNKS
     const chunkIds = Array.from({ length: numChunks }, () =>
-      CHUNK_OPTIONS[Math.floor(Math.random() * CHUNK_OPTIONS.length)]
+      MIDDLE_CHUNK_IDS[Math.floor(Math.random() * MIDDLE_CHUNK_IDS.length)]
     )
 
     console.log(`[Server] New round: ${roundId}, chunks: [${chunkIds.join(' -> ')}]`)

--- a/src/shared/chunks.ts
+++ b/src/shared/chunks.ts
@@ -1,0 +1,34 @@
+export const CHUNK_ASSET_DIR = 'assets/chunks'
+
+export const CHUNK_START_ID = 'ChunkStart'
+export const CHUNK_END_ID = 'ChunkEnd'
+
+export const MIDDLE_CHUNK_IDS = [
+  'Chunk01',
+  'Chunk02',
+  'Chunk03',
+  'Chunk04',
+  'Chunk05',
+  'Chunk06',
+  'Chunk07',
+  'Chunk08',
+  'Chunk09',
+  'Chunk10'
+] as const
+
+export const ALL_CHUNK_IDS = [CHUNK_START_ID, ...MIDDLE_CHUNK_IDS, CHUNK_END_ID] as const
+
+export const MIN_TOWER_MIDDLE_CHUNKS = 3
+export const MAX_TOWER_MIDDLE_CHUNKS = 8
+
+export type ChunkId = (typeof ALL_CHUNK_IDS)[number]
+export type MiddleChunkId = (typeof MIDDLE_CHUNK_IDS)[number]
+
+export function getChunkAssetPath(chunkId: ChunkId | string): string {
+  return `${CHUNK_ASSET_DIR}/${chunkId}.glb`
+}
+
+export function getChunkIdFromAssetPath(assetPath: string): string | null {
+  const match = assetPath.match(/^assets\/chunks\/(\w+)\.glb$/)
+  return match ? match[1] : null
+}

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -48,6 +48,7 @@ import {
   formatTime,
   getTowerChunksFromEntities
 } from "./multiplayer"
+import { CHUNK_END_ID, CHUNK_START_ID, MIDDLE_CHUNK_IDS } from "./shared/chunks"
 import { getSnapshots } from "./snapshots"
 import { OutlinedText, OUTLINE_OFFSETS_16, OUTLINE_OFFSETS_8 } from "./outlinedTextComponent"
 
@@ -57,7 +58,7 @@ export function setupUi() {
 
 // Chunk colors for tower progress bar
 const CHUNK_COLORS: Record<string, Color4> = {
-  'ChunkStart': Color4.create(0.7, 0.5, 0.8, 1),  // Purple (base)
+  [CHUNK_START_ID]: Color4.create(0.7, 0.5, 0.8, 1),  // Purple (base)
   'Chunk01': Color4.create(0.2, 0.8, 0.2, 1),  // Green
   'Chunk02': Color4.create(0.85, 0.75, 0.4, 1),  // Yellow/Tan
   'Chunk03': Color4.create(0.9, 0.9, 0.9, 1),  // White
@@ -68,7 +69,7 @@ const CHUNK_COLORS: Record<string, Color4> = {
   'Chunk08': Color4.create(244 / 255, 242 / 255, 219 / 255, 1),  // #F4F2DB
   'Chunk09': Color4.create(200 / 255, 51 / 255, 92 / 255, 1),  // #C8335C
   'Chunk10': Color4.create(122 / 255, 68 / 255, 148 / 255, 1),  // #7A4494
-  'ChunkEnd': Color4.create(1.0, 0.84, 0.0, 1) // Gold (finish) 
+  [CHUNK_END_ID]: Color4.create(1.0, 0.84, 0.0, 1) // Gold (finish)
 }
 
 const CONNECT_FLOOR_COUNT = 8
@@ -371,9 +372,9 @@ const GameUI = () => {
     const floorStepDuration = CONNECT_FLOOR_STEP_SECONDS
     const activeFloor = Math.floor((nowSeconds / floorStepDuration) % floorCount)
     const loaderFloorPalette = [
-      CHUNK_COLORS.ChunkStart,
-      ...Array.from({ length: 10 }, (_, i) => CHUNK_COLORS[`Chunk${String(i + 1).padStart(2, '0')}`] || Color4.Gray()),
-      CHUNK_COLORS.ChunkEnd
+      CHUNK_COLORS[CHUNK_START_ID],
+      ...MIDDLE_CHUNK_IDS.map((chunkId) => CHUNK_COLORS[chunkId] || Color4.Gray()),
+      CHUNK_COLORS[CHUNK_END_ID]
     ]
     const statusText = `CONNECTING TO SERVER${movingDots}`
 


### PR DESCRIPTION
## Summary

Use `assets/chunks` as the single source of truth for tower chunk assets.

## Changes

- Centralized chunk IDs and asset paths in a shared module
- Updated server chunk spawning to use `assets/chunks`
- Updated `ChunkEnd` to use `assets/chunks/ChunkEnd.glb`
- Updated client chunk parsing to include all chunk GLBs from `assets/chunks`
- Removed duplicated hardcoded chunk lists in UI/runtime

## Validation

- `npm run build`

Closes #101 