### PR TITLE
Fix UI keys

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
 } from '@dcl/sdk/ecs'
 import { Vector3 } from '@dcl/sdk/math'
 import { isServer, isStateSyncronized } from '@dcl/sdk/network'
+import { onEnterScene, onLeaveScene } from '@dcl/sdk/players'
 import { movePlayerTo } from '~system/RestrictedActions'
 import { EntityNames } from '../assets/scene/entity-names'
 import { setupUi } from './ui'
@@ -44,7 +45,7 @@ import {
   WinnerEntry,
   TowerConfig
 } from './multiplayer'
-import { requestPlayerSnapshot } from './snapshots'
+import { requestPlayerSnapshot, setSnapshotHidden } from './snapshots'
 import { TriggerEndComponent } from './shared/schemas'
 
 // ============================================
@@ -402,6 +403,18 @@ export async function main() {
     rejectAttempt(message, title)
   })
 
+  onEnterScene((player) => {
+    const wallet = player.userId?.toLowerCase()
+    if (!wallet) return
+    setSnapshotHidden(wallet, false)
+  })
+
+  onLeaveScene((userId) => {
+    const wallet = userId?.toLowerCase()
+    if (!wallet) return
+    setSnapshotHidden(wallet, true)
+  })
+
   const knownPlayerWallets = new Set<string>()
   engine.addSystem(
     () => {
@@ -410,6 +423,7 @@ export async function main() {
         if (!wallet || knownPlayerWallets.has(wallet)) continue
 
         knownPlayerWallets.add(wallet)
+        setSnapshotHidden(wallet, false)
         const avatarBase = AvatarBase.getOrNull(entity)
         requestPlayerSnapshot(wallet, avatarBase?.name).then((ok) => {
           if (!ok) knownPlayerWallets.delete(wallet)

--- a/src/snapshots.ts
+++ b/src/snapshots.ts
@@ -10,6 +10,7 @@ const snapshots: SnapshotEntry[] = []
 const snapshotByWallet = new Map<string, SnapshotEntry>()
 const hiddenSnapshotWallets = new Set<string>()
 
+const ASSET_BUNDLE_REGISTRY_URL = 'https://asset-bundle-registry.decentraland.org'
 const CATALYST_URL = 'https://peer.decentraland.org'
 const CATALYST_FALLBACKS = [
   'https://peer-ec2.decentraland.org',
@@ -79,6 +80,14 @@ export function isSnapshotHidden(wallet: string): boolean {
 }
 
 async function getPlayerSnapshot(wallet: string): Promise<string | null> {
+  const registryUrl = await getRegistryFaceUrl(wallet)
+  if (registryUrl) {
+    console.log('[Snapshots] OK registry URL for', wallet, registryUrl)
+    return registryUrl
+  }
+
+  console.log('[Snapshots] WARN registry lookup failed for', wallet, '- falling back to catalyst peers')
+
   // Try to get a direct content URL (bypasses Cloudflare CDN - avoids 525 errors)
   const contentUrl = await getContentFaceUrl(wallet)
   if (contentUrl) {
@@ -116,6 +125,54 @@ async function getPlayerSnapshot(wallet: string): Promise<string | null> {
     console.log('[Snapshots] FAIL no valid URL found for', wallet, '- showing placeholder')
   }
   return chosen
+}
+
+async function getRegistryFaceUrl(wallet: string): Promise<string | null> {
+  try {
+    const res = await fetch(`${ASSET_BUNDLE_REGISTRY_URL}/profiles`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json'
+      },
+      body: JSON.stringify({ ids: [wallet] })
+    })
+
+    if (!res.ok) {
+      console.log('[Snapshots][Registry] WARN returned', res.status, 'for', wallet)
+      return null
+    }
+
+    const profiles = await res.json()
+    const profile = Array.isArray(profiles) ? profiles[0] : null
+    const avatar = profile?.avatars?.[0]
+    const rawFace256 = avatar?.avatar?.snapshots?.face256 ?? null
+    const rawFace = avatar?.avatar?.snapshots?.face ?? null
+    const rawBody = avatar?.avatar?.snapshots?.body ?? null
+    const normalizedFace256 = normalizeSnapshotUrl(rawFace256)
+    const normalizedFace = normalizeSnapshotUrl(rawFace)
+
+    console.log(
+      '[Snapshots][Registry] profile for',
+      wallet,
+      JSON.stringify({
+        name: avatar?.name ?? null,
+        hasAvatar: !!avatar?.avatar,
+        face256: rawFace256,
+        face: rawFace,
+        body: rawBody
+      })
+    )
+
+    if (normalizedFace256) return normalizedFace256
+    if (normalizedFace) return normalizedFace
+
+    console.log('[Snapshots][Registry] WARN no valid face snapshot for', wallet)
+    return null
+  } catch (err) {
+    console.log('[Snapshots][Registry] WARN fetch error for', wallet, String(err))
+    return null
+  }
 }
 
 async function getContentFaceUrl(wallet: string): Promise<string | null> {

--- a/src/snapshots.ts
+++ b/src/snapshots.ts
@@ -8,6 +8,7 @@ export type SnapshotEntry = {
 
 const snapshots: SnapshotEntry[] = []
 const snapshotByWallet = new Map<string, SnapshotEntry>()
+const hiddenSnapshotWallets = new Set<string>()
 
 const CATALYST_URL = 'https://peer.decentraland.org'
 const CATALYST_FALLBACKS = [
@@ -20,6 +21,7 @@ export async function requestPlayerSnapshot(wallet: string, displayName?: string
   if (!wallet) return false
 
   const normalized = wallet.toLowerCase()
+  hiddenSnapshotWallets.delete(normalized)
   let entry = snapshotByWallet.get(normalized)
   const isNew = !entry
 
@@ -58,6 +60,22 @@ export async function requestPlayerSnapshot(wallet: string, displayName?: string
 
 export function getSnapshots(): SnapshotEntry[] {
   return snapshots
+}
+
+export function setSnapshotHidden(wallet: string, hidden: boolean) {
+  if (!wallet) return
+
+  const normalized = wallet.toLowerCase()
+  if (hidden) {
+    hiddenSnapshotWallets.add(normalized)
+  } else {
+    hiddenSnapshotWallets.delete(normalized)
+  }
+}
+
+export function isSnapshotHidden(wallet: string): boolean {
+  if (!wallet) return false
+  return hiddenSnapshotWallets.has(wallet.toLowerCase())
 }
 
 async function getPlayerSnapshot(wallet: string): Promise<string | null> {

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -51,7 +51,7 @@ import {
   getTowerChunksFromEntities
 } from "./multiplayer"
 import { CHUNK_END_ID, CHUNK_START_ID, MIDDLE_CHUNK_IDS } from "./shared/chunks"
-import { getSnapshots } from "./snapshots"
+import { getSnapshots, isSnapshotHidden } from "./snapshots"
 import { OutlinedText, OUTLINE_OFFSETS_16, OUTLINE_OFFSETS_8 } from "./outlinedTextComponent"
 
 export function setupUi() {
@@ -164,7 +164,7 @@ const TowerProgressBar = () => {
   const snapshots = getSnapshots()
   const snapshotByWallet = new Map(
     snapshots
-      .filter((entry) => entry.status === 'ok' && entry.snapshotUrl)
+      .filter((entry) => !isSnapshotHidden(entry.wallet) && entry.status === 'ok' && entry.snapshotUrl)
       .map((entry) => [entry.wallet.toLowerCase(), entry.snapshotUrl])
   )
   const localWallet = PlayerIdentityData.getOrNull(engine.PlayerEntity)?.address?.toLowerCase() ?? ''
@@ -194,7 +194,9 @@ const TowerProgressBar = () => {
   }
 
   const rawPlayers = getLocalPlayerHeights(false)
-  const displayedPlayers = [...rawPlayers].sort((a, b) => a.address.localeCompare(b.address))
+  const displayedPlayers = rawPlayers
+    .filter((player) => !isSnapshotHidden(player.address))
+    .sort((a, b) => a.address.localeCompare(b.address))
 
   // Diagnostic: detect player joins/leaves and prevented reorders
   const stableOrder = displayedPlayers.map((p) => p.address)

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -151,8 +151,13 @@ function getWinnerTextColor(index: number, hasEntry: boolean, fallbackColor: Col
   return fallbackColor
 }
 
+// Diagnostic state for progress bar reorder detection
+let _prevStableOrder: string[] = []
+let _prevUnstableOrder: string[] = []
+let _lastReorderLogMs = 0
+
 // Tower Progress Bar Component
-const TowerProgressBar = () => { 
+const TowerProgressBar = () => {
   const s = getScaleUIFactor()
   const uiCanvasInfo = UiCanvasInformation.getOrNull(engine.RootEntity)
   const screenWidth = uiCanvasInfo?.width ?? 1920 * s
@@ -188,7 +193,22 @@ const TowerProgressBar = () => {
     return (clampedHeight / totalHeight) * BAR_WIDTH
   }
 
-  const displayedPlayers = getLocalPlayerHeights(false)
+  const rawPlayers = getLocalPlayerHeights(false)
+  const displayedPlayers = [...rawPlayers].sort((a, b) => a.address.localeCompare(b.address))
+
+  // Diagnostic: detect player joins/leaves and prevented reorders
+  const stableOrder = displayedPlayers.map((p) => p.address)
+  const unstableOrder = rawPlayers.map((p) => p.address)
+  if (stableOrder.length !== _prevStableOrder.length || stableOrder.some((a, i) => a !== _prevStableOrder[i])) {
+    console.log(`[ProgressBar] Players changed ${_prevStableOrder.length}→${stableOrder.length}:`, stableOrder.join(', '))
+    _prevStableOrder = stableOrder
+  }
+  const nowMs = Date.now()
+  if (unstableOrder.length === _prevUnstableOrder.length && unstableOrder.some((a, i) => a !== _prevUnstableOrder[i]) && nowMs - _lastReorderLogMs > 2000) {
+    console.log('[ProgressBar] Prevented height-sort reorder (Godot would recreate nodes):', unstableOrder.join(', '))
+    _lastReorderLogMs = nowMs
+  }
+  _prevUnstableOrder = unstableOrder
 
   return (
     <UiEntity


### PR DESCRIPTION
## Summary
This branch fixes the "avatar turns black" bug in Tower of Madness by implementing proper player snapshot visibility management and stable UI rendering, plus adds improved snapshot loading through the asset bundle registry.

## Key Changes

### 1. Player Enter/Leave Scene Tracking (src/index.ts)
- Added onEnterScene() and onLeaveScene() callbacks from @dcl/sdk/players
- When a player enters the scene, their snapshot is marked as visible
- When a player leaves the scene, their snapshot is hidden (prevents the black avatar bug)
- Snapshots are also explicitly shown when first discovered in the engine system

### 2. Snapshot Visibility Management (src/snapshots.ts)
- New hiddenSnapshotWallets Set tracks which player snapshots should be hidden
- setSnapshotHidden(wallet, hidden) function to show/hide snapshots
- isSnapshotHidden(wallet) function to check visibility status
- Hidden snapshots are filtered out from the UI rendering pipeline

### 3. Asset Bundle Registry Integration (src/snapshots.ts)
- Added new primary snapshot source: https://asset-bundle-registry.decentraland.org/
- getRegistryFaceUrl() function fetches snapshots from the registry first
- Falls back to catalyst peers if registry fails
- Prioritizes face256 → face snapshots from the registry
- Includes comprehensive logging for debugging registry responses

### 4. Stable Player List Rendering (src/ui.tsx)
- Progress bar now uses wallet-based stable sorting instead of height-based sorting
- Players are sorted alphabetically by address: .sort((a, b) => a.address.localeCompare(b.address))
- This prevents React/Godot from recreating UI nodes when player order changes
- Prevents the black avatar bug caused by React ECS key instability

### 5. Diagnostic Logging (src/ui.tsx)
- Tracks and logs when player count changes (joins/leaves)
- Detects when height-based sorting would have caused a reorder (but didn't due to stable sort)
- Throttled logging (max every 2 seconds) to avoid spam
- Example logs:
  - [ProgressBar] Players changed 3→4: 0xabc..., 0xdef..., ...
  - [ProgressBar] Prevented height-sort reorder (Godot would recreate nodes): ...

## Files Modified
- src/index.ts — player scene enter/leave handlers
- src/snapshots.ts — visibility state + asset bundle registry integration
- src/ui.tsx — stable wallet-based sorting + diagnostic logging

This approach ensures UI stability even when player heights change during gameplay, preventing the avatar rendering bug that occurred when React ECS keys were unstable.