### PR TITLE
fix: name refactor in leaderboard

### DIFF
--- a/src/Leaderboard.ts
+++ b/src/Leaderboard.ts
@@ -11,11 +11,12 @@ import { Vector3, Color4, Quaternion } from '@dcl/sdk/math'
 import { EntityNames } from '../assets/scene/entity-names'
 import { LeaderboardEntry } from './multiplayer'
 import { createLeaderboardPanel, setTabData } from './LeaderboardPanel'
+import { formatPlayerNameWithWallet } from './playerNames'
 
 const LEADERBOARD_TEXT_OFFSET = Vector3.create(1.6, 5.5, 0.8)
 const LEADERBOARD_TEXT_ROTATION = Quaternion.fromEulerDegrees(0, 180, 0)
 const LEADERBOARD_TEXT_SCALE = Vector3.create(1.2, 1.2, 1)
-const LEADERBOARD_NAME_WIDTH = 10
+const LEADERBOARD_NAME_WIDTH = 12
 const LEADERBOARD_HEADER_GAP = 4
 const LEADERBOARD_HEADER_BODY_GAP = 0.65
 
@@ -58,10 +59,7 @@ export function setupWorldLeaderboard(
 
     const lines = finishedEntries.map((player, index) => {
       const rank = `${index + 1}.`.padEnd(3)
-      const name = player.displayName.length > LEADERBOARD_NAME_WIDTH
-        ? player.displayName.substring(0, LEADERBOARD_NAME_WIDTH) + '..'
-        : player.displayName
-
+      const name = formatPlayerNameWithWallet(player.displayName, player.address, LEADERBOARD_NAME_WIDTH)
       const namePadded = name.padEnd(LEADERBOARD_NAME_WIDTH)
 
       const hasFinished = player.allTimeFinishCount > 0
@@ -136,7 +134,7 @@ export function setupWorldLeaderboard(
       .slice(0, 10)
 
     return finishedEntries.map((player) => ({
-      name: player.displayName,
+      name: formatPlayerNameWithWallet(player.displayName, player.address, LEADERBOARD_NAME_WIDTH),
       time: `${player.allTimeBestTime.toFixed(2)}s`
     }))
   }
@@ -148,7 +146,7 @@ export function setupWorldLeaderboard(
       .slice(0, 10)
 
     return finishedEntries.map((player) => ({
-      name: player.displayName,
+      name: formatPlayerNameWithWallet(player.displayName, player.address, LEADERBOARD_NAME_WIDTH),
       time: `${player.weeklyBestTime.toFixed(2)}s`
     }))
   }

--- a/src/PointLeaderboard.ts
+++ b/src/PointLeaderboard.ts
@@ -11,11 +11,12 @@ import { Vector3, Color4, Quaternion } from '@dcl/sdk/math'
 import { EntityNames } from '../assets/scene/entity-names'
 import { PointLeaderboardEntry } from './multiplayer'
 import { createPointLeaderboardPanel, setPointTabData } from './PointLeaderboardPanel'
+import { formatPlayerNameWithWallet } from './playerNames'
 
 const POINT_LEADERBOARD_TEXT_OFFSET = Vector3.create(1.6, 5.5, 0.8)
 const POINT_LEADERBOARD_TEXT_ROTATION = Quaternion.fromEulerDegrees(0, 180, 0)
 const POINT_LEADERBOARD_TEXT_SCALE = Vector3.create(1.2, 1.2, 1)
-const POINT_LEADERBOARD_NAME_WIDTH = 10
+const POINT_LEADERBOARD_NAME_WIDTH = 12
 const POINT_LEADERBOARD_HEADER_GAP = 3
 const POINT_LEADERBOARD_HEADER_BODY_GAP = 0.65
 
@@ -62,10 +63,7 @@ export function setupWorldPointLeaderboard(
 
     const lines = topEntries.map((player, index) => {
       const rank = `${index + 1}.`.padEnd(3)
-      const name = player.displayName.length > POINT_LEADERBOARD_NAME_WIDTH
-        ? player.displayName.substring(0, POINT_LEADERBOARD_NAME_WIDTH) + '..'
-        : player.displayName
-
+      const name = formatPlayerNameWithWallet(player.displayName, player.address, POINT_LEADERBOARD_NAME_WIDTH)
       const namePadded = name.padEnd(POINT_LEADERBOARD_NAME_WIDTH)
       return `${rank} ${namePadded}  ${Math.floor(player.points)}`
     })
@@ -134,7 +132,7 @@ export function setupWorldPointLeaderboard(
       .slice(0, 10)
 
     return topEntries.map((player) => ({
-      name: player.displayName,
+      name: formatPlayerNameWithWallet(player.displayName, player.address, POINT_LEADERBOARD_NAME_WIDTH),
       points: `${Math.floor(player.points)}`
     }))
   }
@@ -146,7 +144,7 @@ export function setupWorldPointLeaderboard(
       .slice(0, 10)
 
     return topEntries.map((player) => ({
-      name: player.displayName,
+      name: formatPlayerNameWithWallet(player.displayName, player.address, POINT_LEADERBOARD_NAME_WIDTH),
       points: `${Math.floor(player.points)}`
     }))
   }

--- a/src/playerNames.ts
+++ b/src/playerNames.ts
@@ -1,0 +1,29 @@
+const FALLBACK_PLAYER_NAME = 'Player'
+
+function truncateName(value: string, maxLength?: number): string {
+  if (!maxLength || value.length <= maxLength) return value
+  if (maxLength <= 2) return value.slice(0, maxLength)
+  return `${value.slice(0, maxLength - 2)}..`
+}
+
+export function formatPlayerNameWithWallet(
+  displayName: string | undefined,
+  wallet: string | undefined,
+  maxLength?: number
+): string {
+  const name = displayName?.trim() || FALLBACK_PLAYER_NAME
+  const walletSuffix = wallet?.trim().slice(-4)
+
+  if (!walletSuffix) {
+    return truncateName(name, maxLength)
+  }
+
+  const suffix = `#${walletSuffix}`
+  const fullName = `${name}${suffix}`
+  if (!maxLength || fullName.length <= maxLength) return fullName
+
+  const availableNameLength = maxLength - suffix.length - 2
+  if (availableNameLength <= 0) return suffix.length <= maxLength ? suffix : suffix.slice(-maxLength)
+
+  return `${name.slice(0, availableNameLength)}..${suffix}`
+}

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -53,6 +53,7 @@ import {
 import { CHUNK_END_ID, CHUNK_START_ID, MIDDLE_CHUNK_IDS } from "./shared/chunks"
 import { getSnapshots, isSnapshotHidden } from "./snapshots"
 import { OutlinedText, OUTLINE_OFFSETS_16, OUTLINE_OFFSETS_8 } from "./outlinedTextComponent"
+import { formatPlayerNameWithWallet } from "./playerNames"
 
 export function setupUi() {
   ReactEcsRenderer.setUiRenderer(GameUI)
@@ -131,8 +132,8 @@ function getWinnerFontSize(index: number): number {
   return 22
 }
 
-function truncateWinnerName(name: string): string {
-  return name.length > 8 ? `${name.slice(0, 8)}...` : name
+function truncateWinnerName(name: string, wallet?: string): string {
+  return formatPlayerNameWithWallet(name, wallet, 12)
 }
 
 function formatRoundResultLabel(
@@ -993,9 +994,7 @@ const GameUI = () => {
 
           {leaderboard.slice(0, 10).map((player, index) => {
             const medal = index === 0 ? '1.' : index === 1 ? '2.' : index === 2 ? '3.' : `${index + 1}.`
-            const name = player.displayName.length > 10
-              ? player.displayName.substring(0, 10) + '..'
-              : player.displayName
+            const name = formatPlayerNameWithWallet(player.displayName, player.address, 14)
 
             // Always show all-time bests
             const hasFinished = player.allTimeFinishCount > 0
@@ -1062,9 +1061,7 @@ const GameUI = () => {
             .slice(0, 3)
             .map((player, index) => {
             const medal = index === 0 ? '1.' : index === 1 ? '2.' : '3.'
-            const name = player.displayName.length > 10
-              ? player.displayName.substring(0, 10) + '..'
-              : player.displayName
+            const name = formatPlayerNameWithWallet(player.displayName, player.address, 14)
 
             const statsDisplay = `${player.allTimeBestTime.toFixed(2)}s`
 
@@ -1129,7 +1126,7 @@ const GameUI = () => {
             const display = hasEntry
               ? formatRoundResultLabel(formatTimeMs, winner.time, winner.height)
               : '--:--.--'
-            const name = hasEntry ? truncateWinnerName(winner.displayName) : 'No entries'
+            const name = hasEntry ? truncateWinnerName(winner.displayName, winner.address) : 'No entries'
 
             return (
               <UiEntity


### PR DESCRIPTION
Formats leaderboard player names as name#1234, using the last 4 characters of each player wallet.

Closes #112 