### PR TITLE
ft: block double jump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "devDependencies": {
         "@dcl/asset-packs": "latest",
         "@dcl/hammurabi-server": "^1.0.0-21726116521.commit-148f55a",
-        "@dcl/sdk": "7.20.2-22169778016.commit-030cbfe"
+        "@dcl/js-runtime": "7.21.1-22918726402.commit-ee210ee",
+        "@dcl/sdk": "7.21.1-22918726402.commit-ee210ee"
       },
       "engines": {
         "node": ">=20.0.0",
@@ -194,9 +195,9 @@
       }
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.20.2-22169778016.commit-030cbfe",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.20.2-22169778016.commit-030cbfe.tgz",
-      "integrity": "sha512-481ZiGU8t+WvLhpDJJtUwnGmw8PhkFmNJ1JpsoZyYTM4QXUk0dpcgqeONuVh3j2TGTglnQQwi/BDoyjb2vniKg==",
+      "version": "7.21.1-22918726402.commit-ee210ee",
+      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.21.1-22918726402.commit-ee210ee.tgz",
+      "integrity": "sha512-qR7SoIt9ji+5Wy2SL4s2K2fTmbnTWUCaALeEAmfzKhRA/YCs6B2jm1qvuLEWkiGx5qOZNH0R0K0IiN13Gce/GA==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -302,9 +303,9 @@
       }
     },
     "node_modules/@dcl/inspector/node_modules/@dcl/asset-packs": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-2.14.0.tgz",
-      "integrity": "sha512-p0PR3UGwLbBMFM//Q07jqnLKTVCzIv6Rb+Lwyj1RY5xS61wKB+OBw3P6Py1CG+LrcLspIM6OHagGq1tgccb/QQ==",
+      "version": "2.14.3",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-2.14.3.tgz",
+      "integrity": "sha512-egSrVRg7hNITc+ppiovIYjhdXGwKVeue2ROI9u1G4+Lzos1CTFyX2V1HnYIDb1S1M5vrfNMlfCAFSOGnNim2Rw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -373,9 +374,9 @@
       }
     },
     "node_modules/@dcl/inspector/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -383,13 +384,13 @@
       }
     },
     "node_modules/@dcl/inspector/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -426,9 +427,9 @@
       }
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.20.2-22169778016.commit-030cbfe",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.20.2-22169778016.commit-030cbfe.tgz",
-      "integrity": "sha512-BkB7EJFT3znKeDeSyZcxGje2KNlP8WUXCF3Tx6AagPGj5/zHVbXCzhz2F7IeVrHB797kZAvCY7p1XrO54SlpXA==",
+      "version": "7.21.1-22918726402.commit-ee210ee",
+      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.21.1-22918726402.commit-ee210ee.tgz",
+      "integrity": "sha512-Q088hyE1Bm8Wpxx98BRVJYeRlmZ7ty2E/oCX20Xfdo1uGlgSZ5KHLQMuNDDzi9CSwZj8oeUrzJPLq5py+mvMGQ==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -472,9 +473,9 @@
       }
     },
     "node_modules/@dcl/protocol": {
-      "version": "1.0.0-21519068572.commit-814b279",
-      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-21519068572.commit-814b279.tgz",
-      "integrity": "sha512-AI/Md+BNw60DkBypXVtN7ItWPw3zOexxCf2F1QBSB/0xyxEbz1bukoB419Q3Qe8MEuYIaO/Y4IWM7c7LNpvDXw==",
+      "version": "1.0.0-23951495761.commit-bf007b9",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-23951495761.commit-bf007b9.tgz",
+      "integrity": "sha512-68IwcvwWV6fWxq7ttB1p8BOeNHvxfXnSZ8xd8RvMSPF5CfgaHXcSS5wVbIL6AviJ1l0UMdXLeBje1Op9mVyiXQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -510,13 +511,13 @@
       "license": "MIT"
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.20.2-22169778016.commit-030cbfe",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.20.2-22169778016.commit-030cbfe.tgz",
-      "integrity": "sha512-vJZvZYniW56Gn43jEp8BAgZfox5+Y3XR75T+cpwfavU3NX+hdk42GOqCP8hangej9AFULWm4zq8YI9p+cPUAQg==",
+      "version": "7.21.1-22918726402.commit-ee210ee",
+      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.21.1-22918726402.commit-ee210ee.tgz",
+      "integrity": "sha512-4POOdsqhPekDfd/YiGZ7ZriPxdeD042YkpZR0gGNw1o5e+teYK2faKxwNYBN+9aGIE6DaoqXpRxi8FDiUZiEGQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/ecs": "7.20.2-22169778016.commit-030cbfe",
+        "@dcl/ecs": "7.21.1-22918726402.commit-ee210ee",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -545,37 +546,37 @@
       }
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.20.2-22169778016.commit-030cbfe",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.20.2-22169778016.commit-030cbfe.tgz",
-      "integrity": "sha512-2Tpcg0Dfp5u8azWJebfQnfoGAQSvBW7HeSpvbDWA/KQ04kZOzrLhAZ+KuSXDdoPRK7N+XuDiCgI0hDJzhmblCQ==",
+      "version": "7.21.1-22918726402.commit-ee210ee",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.21.1-22918726402.commit-ee210ee.tgz",
+      "integrity": "sha512-Z5EbZCzQEGUlhZTSo9x42gN8e02PdPE0s1JXKFp863Mzhc6uAnmmJDSe95bQ8VvfJuQcmAeD8nDCbYlo/NC2cQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/ecs": "7.20.2-22169778016.commit-030cbfe",
+        "@dcl/ecs": "7.21.1-22918726402.commit-ee210ee",
         "@dcl/ecs-math": "2.1.0",
         "@dcl/explorer": "1.0.164509-20240802172549.commit-fb95b9b",
-        "@dcl/js-runtime": "7.20.2-22169778016.commit-030cbfe",
-        "@dcl/react-ecs": "7.20.2-22169778016.commit-030cbfe",
-        "@dcl/sdk-commands": "7.20.2-22169778016.commit-030cbfe",
+        "@dcl/js-runtime": "7.21.1-22918726402.commit-ee210ee",
+        "@dcl/react-ecs": "7.21.1-22918726402.commit-ee210ee",
+        "@dcl/sdk-commands": "7.21.1-22918726402.commit-ee210ee",
         "text-encoding": "0.7.0"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.20.2-22169778016.commit-030cbfe",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.20.2-22169778016.commit-030cbfe.tgz",
-      "integrity": "sha512-wXQpdyRaomcqKchJMjaA4KxGJ+7QsRQJD04K+ZQIyHrrJ7IEasAA0ei1FvCnkzIh4FiHjBfZKV6MR1ySV3+SCg==",
+      "version": "7.21.1-22918726402.commit-ee210ee",
+      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.21.1-22918726402.commit-ee210ee.tgz",
+      "integrity": "sha512-grExjVuKhcNOjBE9TFlxEPDYT+hmVgdmMgu3+er43GsSbVc3e7jU29zDXagx0qVWT3E1dtABqLJTsNUc/XQQlg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.20.2-22169778016.commit-030cbfe",
+        "@dcl/ecs": "7.21.1-22918726402.commit-ee210ee",
         "@dcl/gltf-validator-ts": "1.0.14",
         "@dcl/hashing": "1.1.3",
         "@dcl/inspector": "7.25.0",
         "@dcl/linker-dapp": "0.15.0",
         "@dcl/mini-comms": "1.0.1-20230216163137.commit-a4c75be",
-        "@dcl/protocol": "1.0.0-21519068572.commit-814b279",
+        "@dcl/protocol": "1.0.0-22669986637.commit-fb11819",
         "@dcl/quests-client": "^1.0.3",
         "@dcl/quests-manager": "^0.1.4",
         "@dcl/rpc": "^1.1.1",
@@ -609,6 +610,17 @@
       },
       "bin": {
         "sdk-commands": "dist/index.js"
+      }
+    },
+    "node_modules/@dcl/sdk-commands/node_modules/@dcl/protocol": {
+      "version": "1.0.0-22669986637.commit-fb11819",
+      "resolved": "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-22669986637.commit-fb11819.tgz",
+      "integrity": "sha512-/N6EB6wjBbRFvVwZOW5++KIPKSQC7nxoPlIEfRYmR8Ysi1NzPCKHHftg9NiswfTRkyOPcjbaUtq9fT8jkjiTjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@dcl/ts-proto": "1.154.0",
+        "protobufjs": "7.2.4"
       }
     },
     "node_modules/@dcl/ts-proto": {
@@ -1534,9 +1546,9 @@
       }
     },
     "node_modules/@well-known-components/interfaces/node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1702,9 +1714,9 @@
       }
     },
     "node_modules/archiver-utils/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1887,9 +1899,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2982,9 +2994,9 @@
       }
     },
     "node_modules/i18next-fs-backend": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.6.1.tgz",
-      "integrity": "sha512-eYWTX7QT7kJ0sZyCPK6x1q+R63zvNKv2D6UdbMf15A8vNb2ZLyw4NNNZxPFwXlIv/U+oUtg8SakW6ZgJZcoqHQ==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.6.3.tgz",
+      "integrity": "sha512-/5aW996nbolGh/qVU9urjAJ2QiXpiyGuhG8x/ZvvZQ3bMlrK+ouUdD6whS4e+sU9CCdUIzl7x/heEjsBh/3xtw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3101,9 +3113,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/ipfs-unixfs/node_modules/protobufjs": {
-      "version": "6.11.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
-      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
+      "version": "6.11.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.5.tgz",
+      "integrity": "sha512-OKjVH3hDoXdIZ/s5MLv8O2X0s+wOxGfV7ar6WFSKGaSAxi/6gYn3px5POS4vi+mc/0zCOdL7Jkwrj0oT1Yst2A==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -3156,9 +3168,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/ipld-dag-pb/node_modules/protobufjs": {
-      "version": "6.11.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
-      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
+      "version": "6.11.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.5.tgz",
+      "integrity": "sha512-OKjVH3hDoXdIZ/s5MLv8O2X0s+wOxGfV7ar6WFSKGaSAxi/6gYn3px5POS4vi+mc/0zCOdL7Jkwrj0oT1Yst2A==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -5086,9 +5098,9 @@
       }
     },
     "node_modules/zip-stream/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "devDependencies": {
     "@dcl/asset-packs": "latest",
     "@dcl/hammurabi-server": "^1.0.0-21726116521.commit-148f55a",
-    "@dcl/sdk": "7.20.2-22169778016.commit-030cbfe",
-    "@dcl/js-runtime": "7.20.2-22169778016.commit-030cbfe"
+    "@dcl/js-runtime": "7.21.1-22918726402.commit-ee210ee",
+    "@dcl/sdk": "7.21.1-22918726402.commit-ee210ee"
   },
   "engines": {
     "node": ">=20.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
   MeshRenderer,
   Material,
   InputAction,
+  InputModifier,
   pointerEventsSystem
 } from '@dcl/sdk/ecs'
 import { Vector3 } from '@dcl/sdk/math'
@@ -377,6 +378,12 @@ export async function main() {
   // ============================================
   // CLIENT SETUP
   // ============================================
+
+  InputModifier.create(engine.PlayerEntity, {
+    mode: InputModifier.Mode.Standard({
+      disableDoubleJump: true
+    })
+  })
 
   setupClient()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -381,7 +381,8 @@ export async function main() {
 
   InputModifier.create(engine.PlayerEntity, {
     mode: InputModifier.Mode.Standard({
-      disableDoubleJump: true
+      disableDoubleJump: true,
+      disableGliding: true
     })
   })
 


### PR DESCRIPTION
Disables double jump using InputModifier and pins the SDK to the auth-server version to keep server Storage support working.

Closes #111 