### PR TITLE
fix: reset src of chunks after creating new tower

### DIFF
--- a/src/server/gameState.ts
+++ b/src/server/gameState.ts
@@ -418,8 +418,11 @@ export class GameState {
 
   // Tower management
   private destroyTower() {
-    // Hide all pooled entities using VisibilityComponent
     for (const entity of this.towerEntityPool) {
+      // Reset src to empty string so CRDT always emits a delta when createTower assigns a new src.
+      // Without this, if the same chunk asset is reused across rounds the CRDT sees no change and
+      // some clients skip reloading the GLTF, losing colliders on those chunks.
+      GltfContainer.getMutable(entity).src = ''
       VisibilityComponent.getMutable(entity).visible = false
     }
     this.towerEntities = []


### PR DESCRIPTION
Fixed a bug where tower chunks would lose their colliders after round 2 in the deployed version.

Root cause: Tower entities are pooled and reused across rounds. When destroyTower() was called, only VisibilityComponent.visible was set to false — the GltfContainer.src kept its old value. If the next round assigned the same chunk asset to the same pool slot, the CRDT system detected no change in src and sent no update to clients. In the deployed environment, the renderer unloads hidden GLTF models from memory, so without receiving the update the client never reloaded the model — and therefore never re-extracted the colliders.

Fix: Reset GltfContainer.src to '' for all pooled entities in destroyTower(). This guarantees a CRDT delta is always emitted when createTower() assigns the new asset path, forcing the client to reload the model and its colliders regardless of whether the same chunk type was used in the previous round.

Closes #115 