### PR TITLE
fix: chunks colliders

### DIFF
--- a/src/server/gameState.ts
+++ b/src/server/gameState.ts
@@ -539,13 +539,21 @@ export class GameState {
   }
 
   // Round management
+
+  // Called by the server at BREAK-phase start (10 s before startNewRound).
+  // Sending src='' / visible=false here, well ahead of the new-round tick, gives clients
+  // enough time to fully unload the old GLTFs and destroy physics bodies before the new
+  // assets arrive — fixing the missing-collider bug on round 2+.
+  destroyTowerForTransition() {
+    this.destroyTower()
+  }
+
   startNewRound() {
     const roundId = `round_${Date.now()}`
 
-    // Destroy old tower
-    this.destroyTower()
+    // destroyTower() was already called at BREAK-phase start; no need to call it again here.
+    // All pool entities are already src='' / visible=false on all clients.
 
-    // Generate random chunks
     const numChunks =
       Math.floor(Math.random() * (MAX_TOWER_MIDDLE_CHUNKS - MIN_TOWER_MIDDLE_CHUNKS + 1)) +
       MIN_TOWER_MIDDLE_CHUNKS
@@ -555,10 +563,8 @@ export class GameState {
 
     console.log(`[Server] New round: ${roundId}, chunks: [${chunkIds.join(' -> ')}]`)
 
-    // Create new tower
     this.createTower(chunkIds)
 
-    // Reset round state
     const now = Date.now()
     this.roundStartTime = now
     this.finisherCount = 0
@@ -572,7 +578,6 @@ export class GameState {
     roundState.remainingAtSpeedChange = BASE_TIMER
     roundState.finisherCount = 0
 
-    // Reset all players
     this.players.forEach((player) => {
       player.maxHeight = 0
       player.bestTime = 0
@@ -584,12 +589,10 @@ export class GameState {
       player.teleportStrikes = 0
     })
 
-    // Clear winners
     const winners = WinnersComponent.getMutable(this.winnersEntity)
     winners.winners = []
 
     this.podiumServer?.clear()
-
   }
 
   incrementFinisherCount(): number {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -66,7 +66,11 @@ export function server() {
     } else if (phase === RoundPhase.ENDING) {
       const endingElapsed = (Date.now() - roundEndTime) / 1000
       if (endingElapsed >= ROUND_END_DISPLAY_TIME) {
-        console.log(`[Server] ENDING phase done after ${endingElapsed.toFixed(1)}s, starting BREAK`)
+        // Destroy tower NOW so clients get src='' / visible=false 10 s before the new round.
+        // That gap lets them fully unload the GLTFs and destroy physics bodies, so they
+        // recreate colliders cleanly when the new assets arrive in startNewRound().
+        console.log(`[Server] ENDING phase done after ${endingElapsed.toFixed(1)}s, destroying tower and starting BREAK`)
+        gameState.destroyTowerForTransition()
         gameState.setPhase(RoundPhase.BREAK)
         breakStartTime = Date.now()
       }


### PR DESCRIPTION
## Fix: missing colliders on tower chunks from round 2 onwards

### Problem

Tower chunk colliders worked correctly in round 1 but broke on subsequent rounds. Specific chunks — those that reused the same GLB asset at the same pool slot as the previous round — had no physics bodies, causing players to fall through them.

**Root cause:** `destroyTower()` and `createTower()` were both called synchronously inside `startNewRound()`, within the same game tick. The Decentraland CRDT only propagates the net delta per tick, so for chunks reusing the same GLB the net change was zero — clients never received a signal to reload the GLTF. Even when the `src = ''` intermediate reset was added as a workaround, it was immediately overwritten in the same tick and never reached clients as a separate message.

A two-tick approach (sending destroy and build in consecutive ticks) was also attempted but failed because the DCL client caches GLTFs and, when it receives the same `src` value again after a brief `''` state, reuses the cached asset without re-running physics initialization.

### Solution

Move `destroyTowerForTransition()` to the **ENDING → BREAK phase transition**, 10 seconds before `startNewRound()` is called.

This gives clients a guaranteed 10-second window with all pool entities in `src = ''` / `visible = false` state — enough time for the engine to fully evict the cached GLTFs and destroy physics bodies. When `startNewRound()` fires at the end of BREAK and assigns new `src` values, every chunk is treated as a fresh load, recreating colliders correctly regardless of whether the same asset is reused.

### Changes

- `server/gameState.ts` — added `destroyTowerForTransition()` public wrapper; removed `destroyTower()` call from `startNewRound()` (caller is now responsible for calling it ahead of time).
- `server/server.ts` — `destroyTowerForTransition()` is now called at the ENDING → BREAK transition, 10 s before `startNewRound()`.


Closes #135 