### PR TITLE
fix: attempt not counted

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -214,8 +214,7 @@ function setupMessageHandlers(gameState: GameState) {
     if (player.isFinished) return
 
     // Validate: player must be at start area (low height)
-    const liveKitPlayer = getPlayer({ userId: player.address })
-    const currentHeight = liveKitPlayer?.position?.y || 0
+    const currentHeight = getPlayer({ userId: player.address })?.position?.y ?? 0
     const maxStartHeight = 20 // Must be below 20m to start (ground level + tolerance)
 
     if (currentHeight > maxStartHeight) {
@@ -270,8 +269,10 @@ function setupMessageHandlers(gameState: GameState) {
     }
 
     // Validate: player height must be near the top of tower
-    const liveKitPlayer = getPlayer({ userId: player.address })
-    const currentHeight = liveKitPlayer?.position?.y || player.maxHeight
+    // Use Math.max(liveKit, maxHeight) so a stale/missing LiveKit snapshot never zeros out a valid climb.
+    // ?? instead of || avoids treating y=0 as falsy.
+    const liveKitHeight = getPlayer({ userId: player.address })?.position?.y ?? 0
+    const currentHeight = Math.max(liveKitHeight, player.maxHeight)
     const towerConfig = gameState.getTowerConfig()
     const minFinishHeight = towerConfig ? towerConfig.totalHeight - END_TRIGGER_OFFSET : 80
 


### PR DESCRIPTION
## Fix: finish validation rejecting valid attempts ("Attempt Not Counted")

Players who physically reached the top were getting rejected with `FINISH TRIGGER REACHED TOO LOW 0.0m` because the server computed their height as 0.

**Root cause:** Two bugs in the finish height check:

1. `||` operator treated `y = 0` as falsy — if LiveKit returned `0`, it fell back to `player.maxHeight`
2. `getPlayer()` can return `undefined` for a brief moment due to LiveKit's 0.5s update cycle — if that happened at the exact tick the `playerFinished` message arrived, both sides collapsed to `0`

**Fix:** Use `??` (nullish coalescing) to only skip `null`/`undefined`, and take `Math.max(liveKitHeight, player.maxHeight)` so the height accumulated by the server's tracking system serves as a fallback when the LiveKit snapshot is momentarily stale.

Also applied the `??` fix to the `playerStarted` validation for consistency.

## Changes
- `src/server/server.ts`: fix height resolution in `playerFinished` and `playerStarted` handlers

Closes #137 