### PR TITLE
chore: set scene owner to DCL Regenesis Labs

### DIFF
--- a/scene.json
+++ b/scene.json
@@ -7,9 +7,9 @@
     "favicon": "favicon_asset",
     "navmapThumbnail": "assets/images/TOM-Thumbnail.png"
   },
-  "owner": "",
+  "owner": "DCLRegenesisLabs",
   "contact": {
-    "name": "SDK",
+    "name": "DCL Regenesis Labs",
     "email": ""
   },
   "main": "bin/index.js",


### PR DESCRIPTION
Sets `owner` to `DCLRegenesisLabs` and `contact.name` to `DCL Regenesis Labs` in `scene.json`, consistent with the FTUE owner display fix from kickoff-2026#159.

Requested by Gon via Slack