### PR TITLE
ft: add dialogue line

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -761,8 +761,8 @@ export async function main() {
   )
 
   // --- DEBUG TELEPORT TO TOP (disabled — uncomment + re-add inputSystem/PointerEventType imports to re-enable) ---
-  // Press "1" (IA_ACTION_3) anywhere to jump up to the win zone where the pigeon
-  // is — keyboard-only, no entity/pointer involved. Commented out for release.
+  // Press "2" (IA_ACTION_4) anywhere to jump up to the win zone (chunk end) where
+  // the pigeon is — keyboard-only, no entity/pointer involved. Commented out for release.
   //
   // let winZoneTarget: Vector3 | null = null
   //
@@ -787,7 +787,7 @@ export async function main() {
   //
   // engine.addSystem(
   //   () => {
-  //     if (inputSystem.isTriggered(InputAction.IA_ACTION_3, PointerEventType.PET_DOWN)) {
+  //     if (inputSystem.isTriggered(InputAction.IA_ACTION_4, PointerEventType.PET_DOWN)) {
   //       teleportToWinZone()
   //     }
   //   },

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -1014,7 +1014,7 @@ const PigeonClaimDialogBubble = ({
       ? 'Claiming your gift...'
       : pigeonClaimDialogStep === PigeonClaimDialogStep.CLAIMED
       ? 'Congratulations for reaching the top! Your wearable can take a few minutes to arrive.'
-      : 'Once it arrives, you can equip it from your backpack.'
+      : 'Once it arrives, you can equip it from your backpack.\nNow you are ready to continue your adventure! Check out the doors and head to the next experience.'
   const typedText = getCoolBedTypedText(dialogText, stepElapsed)
   const isTyping = typedText.length < dialogText.length
   const showCursor = isTyping && Math.floor(stepElapsed * 4) % 2 === 0
@@ -1045,7 +1045,10 @@ const PigeonClaimDialogBubble = ({
   const avatarDip = avatarSize - avatarProtrusion
 
   const bodyTop = avatarDip + 14
-  const bodyHeight = isLandscapeMobile ? 84 : 104
+  // EQUIP_INFO has two sentences (with an explicit line break) so it needs more
+  // vertical room than the shorter CLAIMING/CLAIMED texts.
+  const isEquipInfoStep = pigeonClaimDialogStep === PigeonClaimDialogStep.EQUIP_INFO
+  const bodyHeight = isEquipInfoStep ? (isLandscapeMobile ? 140 : 170) : isLandscapeMobile ? 84 : 104
   const buttonsTop = bodyTop + bodyHeight + 2
   const bubbleHeight = buttonsTop + 54 + 16
 


### PR DESCRIPTION
## Summary

- Extended the final pigeon wearable-claim dialogue (`EQUIP_INFO` step) with a follow-up line inviting players to head to the next experience through the doors.
- Resized the dialogue bubble's text area for that step so the extra line doesn't overflow or overlap the buttons.
- Debug teleport (win-zone jump) key reference updated from `1` to `2` (`IA_ACTION_4`) in the disabled/commented block, kept off for release.

## Details

- `src/ui.tsx`: `PigeonClaimDialogBubble` now shows:
  > "Once it arrives, you can equip it from your backpack.
  > Now you are ready to continue your adventure! Check out the doors and head to the next experience."
  - Added a dedicated, taller `bodyHeight` for the `EQUIP_INFO` step (140/170px vs. the default 84/104px) since `buttonsTop` and `bubbleHeight` are derived from it.
- `src/index.ts`: updated the commented-out debug teleport block to reference key `2` (`IA_ACTION_4`) instead of `1`, for future re-enabling.

## Test plan

- [x] `npm run build` — passes with no type errors.
- [ ] Manual: claim the pigeon wearable and confirm the final dialogue reads correctly and doesn't overflow its bubble, on both desktop and mobile layouts.


Closes #156