### PR TITLE
ft: invert cinematic order

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -432,16 +432,21 @@ export async function main() {
   setupCinematicSystem()
   setupTutorial()
 
-  // Wait for state sync before playing cinematic on first arrival
+  // Wait for state sync AND a confirmed tower (not just the CRDT dump, which
+  // can land a frame or two before the round/tower data is actually usable)
+  // before starting the first-arrival onboarding sequence — otherwise the
+  // tutorial/cinematic can kick in while chunks are still popping into place.
+  // Mobile players go tutorial -> cinematic (tutorial.ts arms the cinematic
+  // itself once the pigeon tutorial finishes); desktop players never see the
+  // tutorial, so this system plays the intro cinematic for them directly.
   const initialCinematicSystemName = 'initial-cinematic-trigger'
   engine.addSystem(
     () => {
-      if (isStateSyncronized() && shouldAutoPlayCinematic()) {
-        console.log('[Cinematic] State synced, playing initial cinematic')
-        playCinematic()
-        // The pigeon tutorial spawns once this (one-time, intro-only) cinematic ends —
-        // round-transition cinematics call playCinematic() too, but this system only
-        // fires once per client session, so they never re-arm the tutorial.
+      if (isStateSyncronized() && towerConfig !== null && shouldAutoPlayCinematic()) {
+        console.log('[Cinematic] State synced, starting onboarding sequence')
+        // This system only fires once per client session, so it never re-arms
+        // the tutorial on later rounds (round-transition cinematics call
+        // playCinematic() directly, see below).
         armPendingIntroTutorial()
         engine.removeSystem(initialCinematicSystemName)
       }
@@ -658,9 +663,12 @@ export async function main() {
     ColliderLayer.CL_POINTER
   ])
 
-  // Pigeon skin — always visible. Its own visible mesh doubles as the
-  // precise pointer collider (visibleMeshesCollisionMask); any invisible
-  // collider meshes baked into the GLB act as physics + pointer too.
+  // Pigeon skin — hidden until the win-zone system below places it at the
+  // real tower-top position; otherwise it (and the portals) briefly render
+  // at this placeholder spot near the tower base before popping up top.
+  // Its own visible mesh doubles as the precise pointer collider
+  // (visibleMeshesCollisionMask); any invisible collider meshes baked into
+  // the GLB act as physics + pointer too.
   const pigeon = engine.addEntity()
   GltfContainer.create(pigeon, {
     src: 'assets/wearables/PartyPigeon.glb',
@@ -672,6 +680,7 @@ export async function main() {
     position: Vector3.create(0, -0.5, 0),
     scale: Vector3.create(1, 1 / PIGEON_HITBOX_HEIGHT, 1)
   })
+  VisibilityComponent.create(pigeon, { visible: false })
 
   // ============================================
   // WIN-ZONE PORTALS — behind the pigeon, on the win platform
@@ -701,6 +710,10 @@ export async function main() {
       void changeRealm({ realm: 'flagtag.dcl.eth', message: 'Jump to flagtag.dcl.eth?' })
     }
   })
+  // Hidden until the win-zone system below repositions them — same reasoning
+  // as the pigeon's VisibilityComponent above.
+  cozyfarmPortal.setVisible(false)
+  flagtagPortal.setVisible(false)
 
   // Claims the pigeon wearable for the local player via the DCL Rewards API.
   // Uses PIGEON_WEARABLE_CONFIG (separate from the tournament prize campaign).
@@ -797,13 +810,20 @@ export async function main() {
   // ---------------------------------------------------------------------------
 
   // Keep the pigeon (and its click box) glued to the current tower top.
-  // Pigeon stays visible regardless.
+  // Both the pigeon and the portals start hidden (see VisibilityComponent /
+  // setVisible(false) above) and only get revealed here, once we actually
+  // know where the real win-zone is — otherwise they'd flash at their
+  // placeholder position near the tower base for a moment on scene load.
   engine.addSystem(
     () => {
       const triggerEnd = findTriggerEndEntity()
       if (!triggerEnd || !Transform.has(triggerEnd)) {
         return
       }
+
+      VisibilityComponent.getMutable(pigeon).visible = true
+      cozyfarmPortal.setVisible(true)
+      flagtagPortal.setVisible(true)
 
       const center = getWorldPosition(triggerEnd)
       // The meta platform sits at the TriggerEnd center height (server finish check

--- a/src/index.ts
+++ b/src/index.ts
@@ -814,6 +814,7 @@ export async function main() {
   // setVisible(false) above) and only get revealed here, once we actually
   // know where the real win-zone is — otherwise they'd flash at their
   // placeholder position near the tower base for a moment on scene load.
+  let winZoneRevealed = false
   engine.addSystem(
     () => {
       const triggerEnd = findTriggerEndEntity()
@@ -821,9 +822,12 @@ export async function main() {
         return
       }
 
-      VisibilityComponent.getMutable(pigeon).visible = true
-      cozyfarmPortal.setVisible(true)
-      flagtagPortal.setVisible(true)
+      if (!winZoneRevealed) {
+        winZoneRevealed = true
+        VisibilityComponent.getMutable(pigeon).visible = true
+        cozyfarmPortal.setVisible(true)
+        flagtagPortal.setVisible(true)
+      }
 
       const center = getWorldPosition(triggerEnd)
       // The meta platform sits at the TriggerEnd center height (server finish check

--- a/src/portal.ts
+++ b/src/portal.ts
@@ -13,6 +13,7 @@ import {
   TextShape,
   Transform,
   Tween,
+  VisibilityComponent,
   pointerEventsSystem
 } from '@dcl/sdk/ecs'
 import { Color3, Color4, Quaternion, Vector3 } from '@dcl/sdk/math'
@@ -419,6 +420,13 @@ export class Portal {
   updateInfo(name?: string, thumbnail?: string) {
     this.options = { ...this.options, name: name ?? this.options.name, thumbnail: thumbnail ?? this.options.thumbnail }
     this.applyInfo()
+  }
+
+  // Hides/shows the whole portal. Used to keep it out of sight at its
+  // placeholder constructor position until the caller has repositioned it
+  // to the real (tower-height-dependent) win-zone spot via update().
+  setVisible(visible: boolean) {
+    VisibilityComponent.createOrReplace(this.root, { visible })
   }
 
   private applyTransform() {

--- a/src/tutorial.ts
+++ b/src/tutorial.ts
@@ -14,7 +14,7 @@ import {
 import { Vector3, Quaternion } from '@dcl/sdk/math'
 import { isMobile, getPlatform } from '@dcl/sdk/platform'
 import { movePlayerTo } from '~system/RestrictedActions'
-import { isCinematicPlaying } from './cinematicCamera'
+import { playCinematic } from './cinematicCamera'
 import { onTutorialStatus, sendTutorialCompleted } from './multiplayer'
 
 // ============================================
@@ -22,10 +22,13 @@ import { onTutorialStatus, sendTutorialCompleted } from './multiplayer'
 // ============================================
 // Mobile-only. Mandatory on a player's first-ever visit (server has never seen
 // their wallet complete/skip it), skippable on every visit after that. Spawns
-// right after the one-time intro cinematic (not the per-round replay cinematic)
-// and walks the player through movement -> jump/double-jump -> glide, gating
-// their avatar controls with InputModifier along the way. Desktop players never
-// see it — isMobile() comes from the explorer, not just screen size.
+// right on arrival, BEFORE the one-time intro cinematic (not the per-round
+// replay cinematic) — the tutorial itself triggers that cinematic once it
+// finishes (see finishTutorial()) — and walks the player through movement ->
+// jump/double-jump -> glide, gating their avatar controls with InputModifier
+// along the way. Desktop players never see it — isMobile() comes from the
+// explorer, not just screen size — so this module plays the intro cinematic
+// for them directly instead (see updateIntroSpawnWaiting()).
 
 export enum TutorialStep {
   INACTIVE = 'INACTIVE',
@@ -183,6 +186,10 @@ function finishTutorial() {
     tutorialCompletedSent = true
     sendTutorialCompleted()
   }
+
+  // The tutorial now runs before the intro cinematic — trigger it here,
+  // whether the player finished the full flow or hit SKIP on the WELCOME step.
+  playCinematic()
 }
 
 function maybeShowHint(text: string, condition: boolean) {
@@ -218,7 +225,9 @@ export function onSkipClicked() {
   finishTutorial()
 }
 
-// Called once, right when the one-time intro cinematic starts playing.
+// Called once, right when the client's state first syncs on arrival — before
+// the one-time intro cinematic, which now plays after this tutorial finishes
+// (see finishTutorial()) or immediately for desktop players (see below).
 export function armPendingIntroTutorial() {
   pendingIntroSpawn = true
 }
@@ -229,19 +238,21 @@ export function armPendingIntroTutorial() {
 
 function updateIntroSpawnWaiting() {
   if (!pendingIntroSpawn) return
-  if (isCinematicPlaying()) return
 
   // Mobile-only feature — desktop/web players skip it entirely and are never
   // marked as having seen it, so it still triggers if they later join on mobile.
   // getPlatform() resolves asynchronously on scene load; give it a short grace
-  // window here in case it hasn't landed yet by the time the cinematic ends.
+  // window here in case it hasn't landed yet.
   if (getPlatform() === null) {
     if (platformWaitStartedAt === 0) platformWaitStartedAt = Date.now()
     if (Date.now() - platformWaitStartedAt < PLATFORM_TIMEOUT_MS) return
   }
 
   if (!isMobile()) {
+    // No tutorial for desktop — go straight to the intro cinematic, same as
+    // before this module ever gets involved.
     pendingIntroSpawn = false
+    playCinematic()
     return
   }
 


### PR DESCRIPTION
## Summary

- Reordered the first-arrival onboarding sequence so the mobile pigeon tutorial now plays **before** the intro cinematic, instead of after it.
- Fixed a visual glitch where the win-zone pigeon and portals briefly popped in at a placeholder position near the tower base before jumping up to their real spot once the tower synced.
- Tightened the onboarding trigger so it waits for a confirmed tower, not just the initial CRDT sync, avoiding a jarring "world still assembling" moment right as the tutorial/cinematic kicks in.

## Details

### Tutorial/cinematic reorder
- `src/tutorial.ts`: removed the `isCinematicPlaying()` gate that made the tutorial wait for the cinematic to finish. The tutorial now starts as soon as it's armed.
  - Desktop players (no tutorial): `updateIntroSpawnWaiting()` now calls `playCinematic()` directly, same behavior as before.
  - Mobile players: `finishTutorial()` (reached both via full completion and via the SKIP button on the WELCOME step) now triggers `playCinematic()` once the tutorial is done. This preserves the existing WELCOME/TRY/SKIP UI for returning players — no change to their ability to replay it.
- `src/index.ts`: the `initial-cinematic-trigger` system no longer calls `playCinematic()` directly — it only arms the tutorial (`armPendingIntroTutorial()`), which now owns deciding when the cinematic plays for each platform.

### Pop-in fix (pigeon + portals)
- `src/portal.ts`: added `Portal.setVisible(visible)` (backed by `VisibilityComponent` on the portal root).
- `src/index.ts`:
  - The pigeon and both portals (`cozyfarmPortal`, `flagtagPortal`) now start hidden right after creation, since they're initialized at a placeholder position (`y: 5`, near the tower base) until the real win-zone transform is known.
  - The `pigeon-teleport-system` reveals all three the moment it successfully resolves the tower's `TriggerEnd` entity and repositions them — so they only ever become visible already in their final spot.

### Onboarding trigger timing
- `src/index.ts`: the `initial-cinematic-trigger` system now also waits for `towerConfig !== null`, not just `isStateSyncronized()`, since CRDT sync can land a frame or two before the round/tower data is actually populated. This keeps the tutorial/cinematic from starting while the tower is still being built.

## Test plan

- [x] `npm run build` — passes with no type errors.
- [ ] Manual, mobile: fresh wallet (first-time) sees tutorial → cinematic → gameplay, with no visible pigeon/portals until they're in the right spot.
- [ ] Manual, mobile: returning wallet (already completed tutorial) can still press TRY to replay or SKIP, and the cinematic plays right after either path.
- [ ] Manual, desktop: cinematic still plays immediately on arrival, no tutorial shown.

Closes #155 