### PR TITLE
ft: lock skybox to midday

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
   Material,
   InputAction,
   InputModifier,
+  SkyboxTime,
   pointerEventsSystem
 } from '@dcl/sdk/ecs'
 import { Vector3 } from '@dcl/sdk/math'
@@ -396,6 +397,10 @@ export async function main() {
   // ============================================
   // CLIENT SETUP
   // ============================================
+
+  // Force midday skybox at runtime — scene.json's skyboxConfig.fixedTime sets the
+  // manifest default, but this pins it in-world regardless of realm/portal overrides.
+  SkyboxTime.createOrReplace(engine.RootEntity, { fixedTime: 43200 })
 
   InputModifier.create(engine.PlayerEntity, {
     mode: InputModifier.Mode.Standard({


### PR DESCRIPTION
## Summary

- Locked the scene's skybox to a fixed midday time (12:00, `fixedTime: 43200`), matching the setup already used in the `cozy-farm` scene.
- `scene.json` already had `skyboxConfig.fixedTime: 43200` as the manifest default, but that alone doesn't hold once a player arrives via a realm change or portal with a different time override — this pins it explicitly at runtime.

## Details

- `src/index.ts`: added the `SkyboxTime` import from `@dcl/sdk/ecs` and, right at the start of the client branch in `main()`, `SkyboxTime.createOrReplace(engine.RootEntity, { fixedTime: 43200 })`.

## Test plan

- [x] `npm run build` — passes with no type errors.
- [ ] Manual: enter the scene (including via portal from another realm) and confirm the skybox is always at midday regardless of how you arrived.


Closes #157 