### PR TITLE
fix: save tutorial seen

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,9 @@ import {
   InputAction,
   InputModifier,
   SkyboxTime,
-  pointerEventsSystem
+  pointerEventsSystem,
+  inputSystem,
+  PointerEventType
 } from '@dcl/sdk/ecs'
 import { Vector3, Color4, Quaternion } from '@dcl/sdk/math'
 import { isServer, isStateSyncronized } from '@dcl/sdk/network'
@@ -786,40 +788,39 @@ export async function main() {
     () => { void claimPigeonWearable() }
   )
 
-  // --- DEBUG TELEPORT TO TOP (disabled — uncomment + re-add inputSystem/PointerEventType imports to re-enable) ---
+  // --- DEBUG TELEPORT TO TOP -----------------------------------------------------
   // Press "2" (IA_ACTION_4) anywhere to jump up to the win zone (chunk end) where
-  // the pigeon is — keyboard-only, no entity/pointer involved. Commented out for release.
-  //
-  // let winZoneTarget: Vector3 | null = null
-  //
-  // function teleportToWinZone() {
-  //   if (!winZoneTarget) {
-  //     console.log('[Teleport] No win zone yet (tower not ready)')
-  //     return
-  //   }
-  //   // Landing in the win zone would otherwise fire the finish trigger and bounce
-  //   // the player back to base. Suppress it briefly so the teleport sticks.
-  //   suppressEndTriggerUntil = Date.now() + 3000
-  //   const pigeonPos = getWorldPosition(pigeon)
-  //   movePlayerTo({
-  //     newRelativePosition: winZoneTarget,
-  //     cameraTarget: {
-  //       x: pigeonPos.x,
-  //       y: pigeonPos.y + 1.2,
-  //       z: pigeonPos.z
-  //     }
-  //   })
-  // }
-  //
-  // engine.addSystem(
-  //   () => {
-  //     if (inputSystem.isTriggered(InputAction.IA_ACTION_4, PointerEventType.PET_DOWN)) {
-  //       teleportToWinZone()
-  //     }
-  //   },
-  //   undefined,
-  //   'debug-teleport-key-system'
-  // )
+  // the pigeon is — keyboard-only, no entity/pointer involved.
+  let winZoneTarget: Vector3 | null = null
+
+  function teleportToWinZone() {
+    if (!winZoneTarget) {
+      console.log('[Teleport] No win zone yet (tower not ready)')
+      return
+    }
+    // Landing in the win zone would otherwise fire the finish trigger and bounce
+    // the player back to base. Suppress it briefly so the teleport sticks.
+    suppressEndTriggerUntil = Date.now() + 3000
+    const pigeonPos = getWorldPosition(pigeon)
+    movePlayerTo({
+      newRelativePosition: winZoneTarget,
+      cameraTarget: {
+        x: pigeonPos.x,
+        y: pigeonPos.y + 1.2,
+        z: pigeonPos.z
+      }
+    })
+  }
+
+  engine.addSystem(
+    () => {
+      if (inputSystem.isTriggered(InputAction.IA_ACTION_4, PointerEventType.PET_DOWN)) {
+        teleportToWinZone()
+      }
+    },
+    undefined,
+    'debug-teleport-key-system'
+  )
   // ---------------------------------------------------------------------------
 
   // Keep the pigeon (and its click box) glued to the current tower top.
@@ -903,13 +904,14 @@ export async function main() {
         { x: 0, y: portalYaw, z: 0 }
       )
 
-      // Debug teleport target (disabled — re-enable with the teleport block above):
-      // const PIGEON_TELEPORT_DISTANCE_M = 4.5
-      // winZoneTarget = Vector3.create(
-      //   center.x + faceDir.x * PIGEON_TELEPORT_DISTANCE_M,
-      //   floorY + 1,
-      //   center.z + faceDir.z * PIGEON_TELEPORT_DISTANCE_M
-      // )
+      // Debug teleport target — lands the player just in front of the pigeon
+      // (reuses the yaw/faceDir already computed for the portals above).
+      const PIGEON_TELEPORT_DISTANCE_M = 4.5
+      winZoneTarget = Vector3.create(
+        center.x + faceDir.x * PIGEON_TELEPORT_DISTANCE_M,
+        floorY + 1,
+        center.z + faceDir.z * PIGEON_TELEPORT_DISTANCE_M
+      )
     },
     undefined,
     'pigeon-teleport-system'

--- a/src/server/gameState.ts
+++ b/src/server/gameState.ts
@@ -42,7 +42,8 @@ function protectServerEntity(entity: Entity, components: ComponentWithValidation
 }
 
 // Constants
-const BASE_TIMER = 420 // 7 minutes
+// DEBUG: shortened from 420 (7 minutes) to 35s for faster round-to-round testing. Revert before release.
+const BASE_TIMER = 35
 const CHUNK_HEIGHT = 10.821
 const TOWER_X = 40
 const TOWER_Z = 40
@@ -58,6 +59,7 @@ const POINTS_WEEKLY_LEADERBOARD_KEY = 'weeklyPointLeaderboard'
 const POINTS_WEEKLY_LEADERBOARD_SIZE = 10
 const TOURNAMENT_STATE_KEY = 'tournamentState'
 const TOURNAMENT_LEADERBOARD_KEY = 'tournamentLeaderboard'
+const TUTORIAL_SEEN_KEY = 'tutorialSeen'
 
 function getWeekStartKeyUTC(now: number = Date.now()): string {
   const d = new Date(now)
@@ -179,7 +181,8 @@ export class GameState {
   private finisherCount: number = 0
 
   // Players who have completed (or skipped) the pigeon tutorial at least once.
-  // In-memory only, resets on server restart — same as allTimeBests.
+  // Persisted to Storage (see loadTutorialSeen/persistTutorialSeen) — same
+  // pattern as allTimeBests, so it survives server restarts.
   private tutorialSeen = new Set<string>()
 
   // All-time best scores (persisted)
@@ -338,6 +341,7 @@ export class GameState {
     void this.loadGlobalPointLeaderboard()
     void this.loadWeeklyPointLeaderboard()
     void this.restoreTournamentState()
+    void this.loadTutorialSeen()
   }
 
   // Player management (normalize address to lowercase for consistency)
@@ -351,6 +355,36 @@ export class GameState {
 
   markTutorialSeen(address: string) {
     this.tutorialSeen.add(address.toLowerCase())
+    void this.persistTutorialSeen()
+  }
+
+  private async loadTutorialSeen() {
+    if (!isServer()) return
+
+    try {
+      const stored = await Storage.get<string>(TUTORIAL_SEEN_KEY)
+      if (!stored) return
+
+      const addresses = JSON.parse(stored) as string[]
+      for (const address of addresses) {
+        if (!address) continue
+        this.tutorialSeen.add(address.toLowerCase())
+      }
+
+      console.log(`[Server][Storage] Loaded tutorialSeen: ${addresses.length} players`)
+    } catch (error) {
+      console.error('[Server][Storage] Failed to load tutorialSeen:', error)
+    }
+  }
+
+  private async persistTutorialSeen() {
+    if (!isServer()) return
+
+    try {
+      await Storage.set(TUTORIAL_SEEN_KEY, JSON.stringify(Array.from(this.tutorialSeen)))
+    } catch (error) {
+      console.error('[Server][Storage] Failed to save tutorialSeen:', error)
+    }
   }
 
   setPlayer(address: string, data: PlayerData) {


### PR DESCRIPTION
# Persist tutorialSeen to Storage + debug aids

## Summary

Makes the "has this wallet seen the tutorial" flag survive server restarts (previously in-memory only), and re-enables two debug conveniences for faster iteration testing.

## What's in this change

### `src/server/gameState.ts` — persist `tutorialSeen`
- `tutorialSeen` (`Set<string>` of wallet addresses) now persists to `Storage` under the `tutorialSeen` key, same pattern already used for `allTimeBests`/leaderboards.
- `loadTutorialSeen()` — loads the saved address list once on server init (alongside the existing `loadGlobalLeaderboard`, etc. calls) and repopulates the `Set`.
- `persistTutorialSeen()` — writes the full `Set` back to `Storage`, called from `markTutorialSeen()` every time a player completes/skips the tutorial (fire-and-forget, same as the leaderboard persistence calls).
- Previously this reset on every server restart, forcing every returning player through the mandatory tutorial again — now it's permanent, matching how per-player leaderboard data already behaves.

### `src/index.ts` — re-enabled debug teleport
- Uncommented the "press 2 (`IA_ACTION_4`) to jump to the win zone / chunk end" debug teleport (keyboard-only, no entity/pointer), including the `winZoneTarget` computation in the `pigeon-teleport-system` and the `inputSystem`/`PointerEventType` imports it needs.

### `src/server/gameState.ts` — debug round timer
- `BASE_TIMER` temporarily dropped from `420` (7 min) to `35` seconds for faster round-to-round testing. Marked with a `// DEBUG:` comment — **needs reverting to 420 before release.**

## Test plan
- [ ] Complete/skip the tutorial as a wallet that's never seen it, restart the server, rejoin — tutorial should now be skippable (not mandatory again).
- [ ] Fresh wallet still gets the mandatory tutorial on first-ever visit.
- [ ] Press "2" anywhere in the scene — teleports to the win zone in front of the pigeon, camera facing it.
- [ ] Rounds now last ~35s instead of 7 minutes — confirm this is intentional for the current testing pass, and revert `BASE_TIMER` before shipping.
