### PR TITLE
FIX: Force a tower reset on server boot to prevent duplicate/stale to…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -658,9 +658,14 @@ export async function main() {
   // off a parent that's shifted up and stretched.
   const PIGEON_HITBOX_HEIGHT = 4.9
   const PIGEON_HITBOX_RADIUS = 1.1
+  // Placeholder position is deliberately far below the map (not near the
+  // tower base) — this collider has no VisibilityComponent to hide it like
+  // the pigeon model does, so until the win-zone system below gives it a
+  // real position, it must not sit somewhere a player could actually reach
+  // and click it (see the towerConfig guard in pigeon-teleport-system).
   const pigeonClick = engine.addEntity()
   Transform.create(pigeonClick, {
-    position: Vector3.create(40, 5, 40),
+    position: Vector3.create(40, -100, 40),
     scale: Vector3.create(1, PIGEON_HITBOX_HEIGHT, 1)
   })
   MeshCollider.setCylinder(pigeonClick, PIGEON_HITBOX_RADIUS, PIGEON_HITBOX_RADIUS, [
@@ -827,11 +832,20 @@ export async function main() {
   // setVisible(false) above) and only get revealed here, once we actually
   // know where the real win-zone is — otherwise they'd flash at their
   // placeholder position near the tower base for a moment on scene load.
+  //
+  // triggerEnd EXISTING isn't enough to trust its position: it's a single
+  // persistent entity created once at server boot with a placeholder
+  // Transform (~ground level, right by ChunkStart's ramp) and only gets its
+  // real height from createTower() — which the server now deliberately
+  // delays a few seconds on boot (see BOOT_TOWER_DELAY in server.ts) to let
+  // stale/reconnecting clients resync. Without the towerConfig check below,
+  // that gap was exactly reproducing the reported bug: the claim hitbox
+  // ("Claim will be available soon") sitting down at the tower base.
   let winZoneRevealed = false
   engine.addSystem(
     () => {
       const triggerEnd = findTriggerEndEntity()
-      if (!triggerEnd || !Transform.has(triggerEnd)) {
+      if (!triggerEnd || !Transform.has(triggerEnd) || !towerConfig || towerConfig.chunkIds.length === 0) {
         return
       }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -7,6 +7,8 @@ import { TOURNAMENT_CONFIG } from './tournamentConfig'
 
 const ROUND_END_DISPLAY_TIME = 3 // seconds
 const NEW_ROUND_DELAY = 10 // seconds
+const BOOT_TOWER_DELAY = 3 // seconds — shorter than NEW_ROUND_DELAY: this only needs to
+// cover a resync settling, not the "give players a breather" purpose the between-round gap serves.
 const MAX_UP_SPEED = 12 // m/s allowed upward speed before considering teleport
 const HEIGHT_TOLERANCE = 0.5 // m of extra leeway per sample
 const HARD_MAX_DELTA = 20 // m allowed upward jump regardless of sample time
@@ -19,14 +21,26 @@ export function server() {
 
   const gameState = GameState.getInstance()
   gameState.init()
-  gameState.startNewRound()
+
+  // Force every tower chunk hidden/reset before building the first tower —
+  // same idea as the ENDING->BREAK transition between rounds, but shorter.
+  // This matters if the server process restarted (redeploy/crash) while a
+  // client was still connected: that client may still be rendering tower
+  // entities from the previous server generation, which this fresh process
+  // has no way to reference or delete directly. Explicitly re-broadcasting
+  // "hidden" here — then waiting a beat before actually building the tower —
+  // gives any such stale client's resync time to settle first, so it can
+  // never render an old tower overlapping a new one.
+  gameState.destroyTowerForTransition()
+  gameState.setPhase(RoundPhase.BREAK)
+  let bootBreak = true
 
   setupMessageHandlers(gameState)
 
   // Timer system
   let lastUpdate = 0
   let roundEndTime = 0
-  let breakStartTime = 0
+  let breakStartTime = Date.now()
   // Auto-start deferred: wait ~2s after boot so restoreTournamentState() can complete first
   let autoStartDelay = (TOURNAMENT_CONFIG.tournamentMode && TOURNAMENT_CONFIG.autoStart) ? 2 : -1
 
@@ -72,11 +86,14 @@ export function server() {
         console.log(`[Server] ENDING phase done after ${endingElapsed.toFixed(1)}s, destroying tower and starting BREAK`)
         gameState.destroyTowerForTransition()
         gameState.setPhase(RoundPhase.BREAK)
+        bootBreak = false
         breakStartTime = Date.now()
       }
     } else if (phase === RoundPhase.BREAK) {
       const breakElapsed = (Date.now() - breakStartTime) / 1000
-      if (breakElapsed >= NEW_ROUND_DELAY) {
+      const delay = bootBreak ? BOOT_TOWER_DELAY : NEW_ROUND_DELAY
+      if (breakElapsed >= delay) {
+        bootBreak = false
         console.log(`[Server] BREAK phase done after ${breakElapsed.toFixed(1)}s, starting new round`)
         gameState.startNewRound()
       }


### PR DESCRIPTION
# Force a tower reset on server boot to prevent duplicate/stale towers

## Summary

Adds a defensive fix for a reported bug where a player's client showed an old tower overlapping a new one, with some chunks sitting unpositioned at ground level. Root cause (most likely): the server process restarted (redeploy/crash) while that client was still connected, so it kept rendering tower chunk entities from the previous server generation while also receiving the fresh session's entities.

## What's in this change

### `src/server/server.ts`
- On boot, instead of building the tower immediately (`startNewRound()`), the server now:
  1. Calls `destroyTowerForTransition()` first — explicitly re-broadcasts every tower chunk as hidden/`src=''`, same mechanism already used between rounds (ENDING → BREAK). This is the only lever the server has to correct a client that might still be rendering entities from a previous server generation it has no reference to.
  2. Sets phase to `BREAK` and waits a short `BOOT_TOWER_DELAY` (3s) before calling `startNewRound()` — reuses the existing BREAK-phase timer branch in the round loop, just with a shorter delay than the normal between-round `NEW_ROUND_DELAY` (10s).
- The delay is intentionally **shorter than the between-round gap**: reusing the full 10s would mean every player joining right after a routine server restart waits 10s to see a tower, not just the rare case this is meant to catch. 3s is enough for a stale client's resync to settle without meaningfully degrading the normal boot experience.

## Known trade-off
- Any player who joins in that first ~3s window after server boot will see no tower (bare base, no chunks) until it's built. This only happens right at server start, not during normal play — considered an acceptable trade vs. the alternative (nothing preventing the duplicate-tower bug).

## Test plan
- [ ] Restart the server and join immediately — tower is briefly absent (~3s), then builds normally, no duplicate/overlapping chunks.
- [ ] Normal round transitions (ENDING → BREAK → new round) still take the full 10s as before, unaffected by the new boot-only delay.
- [ ] If possible, reproduce the original report: stay connected through a server restart and confirm no old+new tower overlap afterward.

Closes #164 