### PR TITLE
Add posthog analytics

### DIFF
--- a/scene.json
+++ b/scene.json
@@ -105,7 +105,7 @@
   "authoritativeMultiplayer": true,
   "multiplayerId": "towerofmadness",
   "worldConfiguration": {
-    "name": "towerofmadness.dcl.eth"
+    "name": "yiffer.dcl.eth"
   },
   "logsPermissions": [
     "0xb8c4df381c6c305758f806c3aa71f37aabbcbd92",

--- a/scene.json
+++ b/scene.json
@@ -88,7 +88,8 @@
   ],
   "requiredPermissions": [
     "ALLOW_TO_TRIGGER_AVATAR_EMOTE",
-    "ALLOW_TO_MOVE_PLAYER_INSIDE_SCENE"
+    "ALLOW_TO_MOVE_PLAYER_INSIDE_SCENE",
+    "USE_FETCH"
   ],
   "featureToggles": {
     "voiceChat": "enabled",
@@ -105,7 +106,7 @@
   "authoritativeMultiplayer": true,
   "multiplayerId": "towerofmadness",
   "worldConfiguration": {
-    "name": "yiffer.dcl.eth"
+    "name": "towerofmadness.dcl.eth"
   },
   "logsPermissions": [
     "0xb8c4df381c6c305758f806c3aa71f37aabbcbd92",

--- a/src/chunkPreload.ts
+++ b/src/chunkPreload.ts
@@ -1,0 +1,61 @@
+import { engine, Transform, GltfContainer, GltfContainerLoadingState, LoadingState, Entity } from '@dcl/sdk/ecs'
+import { Vector3 } from '@dcl/sdk/math'
+import { ALL_CHUNK_IDS, getChunkAssetPath } from './shared/chunks'
+
+// ============================================================================
+// CHUNK ASSET PRELOAD (client-only)
+// ----------------------------------------------------------------------------
+// Root cause of the "fall through renewed chunks" bug: the FIRST time a chunk
+// GLB is loaded it must be downloaded (cold cache). The renderer shows the
+// visible mesh as soon as it can, but the physics collider (from the GLB's
+// `*_collider` mesh) only becomes active once the GLB reaches FINISHED. On a
+// cold load that window is seconds long, so a player climbing the freshly
+// renewed tower reaches the lower chunks before their colliders exist → falls.
+// Once a GLB is cached, reloads are sub-second and the window disappears.
+//
+// Fix: warm the cache for EVERY chunk GLB once, at scene start (while the player
+// is still at the base), so no tower renewal ever hits a cold download again.
+// We spawn a tiny, tucked-away entity per distinct GLB just to force the
+// download, then remove it as soon as it finishes — the asset stays cached.
+// ============================================================================
+
+export function setupChunkPreload(): void {
+  const srcs = Array.from(new Set(ALL_CHUNK_IDS.map((id) => getChunkAssetPath(id))))
+  const pending = new Set<Entity>()
+
+  for (const src of srcs) {
+    const e = engine.addEntity()
+    // Tiny (1mm) and off in a corner so it's effectively invisible; it exists
+    // only to make the renderer download + cache the GLB.
+    Transform.create(e, {
+      position: Vector3.create(0.5, 0.5, 0.5),
+      scale: Vector3.create(0.001, 0.001, 0.001)
+    })
+    GltfContainer.create(e, { src })
+    pending.add(e)
+  }
+
+  const startedAt = Date.now()
+  console.log(`[ChunkPreload] warming ${pending.size} chunk GLBs at startup...`)
+
+  function preloadSystem(): void {
+    for (const e of pending) {
+      const state = GltfContainerLoadingState.getOrNull(e)?.currentState
+      // Done (or failed) → drop the temp entity; the downloaded asset stays cached.
+      if (
+        state === LoadingState.FINISHED ||
+        state === LoadingState.FINISHED_WITH_ERROR ||
+        state === LoadingState.NOT_FOUND
+      ) {
+        pending.delete(e)
+        engine.removeEntity(e)
+      }
+    }
+    if (pending.size === 0) {
+      console.log(`[ChunkPreload] ✓ all chunk GLBs cached after ${((Date.now() - startedAt) / 1000).toFixed(1)}s`)
+      engine.removeSystem(preloadSystem)
+    }
+  }
+
+  engine.addSystem(preloadSystem, undefined, 'chunk-preload-system')
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,12 +57,13 @@ import { signedFetch } from '~system/SignedFetch'
 import { room } from './shared/messages'
 import { setupCinematicSystem, playCinematic, shouldAutoPlayCinematic, isCinematicPlaying } from './cinematicCamera'
 import { setupTutorial, armPendingIntroTutorial, tutorialStep, TutorialStep } from './tutorial'
+import { setupChunkPreload } from './chunkPreload'
 
 // ============================================
 // GAME STATE
 // ============================================
 import { initTimeSync } from './shared/timeSync'
-;(globalThis as any).DEBUG_NETWORK_MESSAGES = true
+;(globalThis as any).DEBUG_NETWORK_MESSAGES = false
 
 // Player tracking
 export let playerHeight = 0
@@ -436,6 +437,7 @@ export async function main() {
   setupClient()
   setupCinematicSystem()
   setupTutorial()
+  setupChunkPreload() // warm the chunk asset cache so renewals never cold-load (fixes fall-through)
 
   // Wait for state sync AND a confirmed tower (not just the CRDT dump, which
   // can land a frame or two before the round/tower data is actually usable)

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4,6 +4,7 @@ import { GameState } from './gameState'
 import { room } from '../shared/messages'
 import { RoundPhase, TournamentComponent } from '../shared/schemas'
 import { TOURNAMENT_CONFIG } from './tournamentConfig'
+import { trackEvent } from '../shared/analytics'
 
 const ROUND_END_DISPLAY_TIME = 3 // seconds
 const NEW_ROUND_DELAY = 10 // seconds
@@ -15,6 +16,12 @@ const HARD_MAX_DELTA = 20 // m allowed upward jump regardless of sample time
 const TELEPORT_BASE = { x: 45, y: 2.5, z: 59 }
 const END_TRIGGER_OFFSET = 11
 const ROUND_TIMER_CHECK_INTERVAL = 0.25 // seconds
+
+// Analytics: guard `session started` against double-firing on reconnects /
+// repeated playerJoin messages. A genuine new session (scene re-entry) is
+// minutes apart, so a short window only collapses rapid duplicates.
+const SESSION_DEDUP_MS = 30_000
+const lastSessionStartedAt = new Map<string, number>()
 
 export function server() {
   console.log('[Server] Tower of Madness starting...')
@@ -221,6 +228,17 @@ function setupMessageHandlers(gameState: GameState) {
       address: context.from,
       hasSeenTutorial: gameState.hasSeenTutorial(context.from)
     })
+
+    // Analytics — one `session started` per scene entry (unlocks D1/D7/D30
+    // retention, keyed by wallet). Deduped against rapid repeat joins.
+    const now = Date.now()
+    const lastStart = lastSessionStartedAt.get(context.from) ?? 0
+    if (now - lastStart > SESSION_DEDUP_MS) {
+      lastSessionStartedAt.set(context.from, now)
+      trackEvent('session started', context.from, {
+        is_new_user: !gameState.hasSeenTutorial(context.from)
+      })
+    }
   })
 
   // Player finished (or skipped) the pigeon tutorial

--- a/src/shared/analytics.ts
+++ b/src/shared/analytics.ts
@@ -1,0 +1,61 @@
+import { signedFetch } from '~system/SignedFetch'
+import { ANALYTICS_CONFIG } from './analyticsConfig'
+
+/**
+ * The single choke point for ALL analytics. Nothing else in the codebase talks
+ * to PostHog directly — swap this file to change providers.
+ *
+ * - Fire-and-forget: never awaited on the gameplay path, never throws.
+ * - Provider-agnostic to callers: they only pass a name, the player's wallet,
+ *   and optional properties.
+ * - Works from both client and server (both have `signedFetch`; PostHog ignores
+ *   the DCL auth headers it adds).
+ *
+ * Adding a new event = one more `trackEvent(...)` call. No new plumbing.
+ *
+ * @param name        Event name, PostHog "[object] [verb]" lowercase style
+ *                    (e.g. 'session started', 'tutorial step reached').
+ * @param distinctId  The player's wallet address — the identity that ties
+ *                    multiple sessions to one person (required for retention).
+ * @param properties  Extra event properties. `game` + `$lib` are added here.
+ */
+export function trackEvent(name: string, distinctId: string, properties: Record<string, unknown> = {}): void {
+  if (!ANALYTICS_CONFIG.enabled) return
+  if (!distinctId) return // no wallet → no identity; skip rather than send anonymous
+
+  try {
+    let timestamp: string | undefined
+    try {
+      timestamp = new Date(Date.now()).toISOString()
+    } catch {
+      timestamp = undefined // PostHog falls back to receive time
+    }
+
+    const body = {
+      api_key: ANALYTICS_CONFIG.projectApiKey,
+      event: name,
+      distinct_id: distinctId.toLowerCase(),
+      timestamp,
+      properties: {
+        game: ANALYTICS_CONFIG.gameId,
+        $lib: 'dcl-sdk7-custom',
+        ...properties
+      }
+    }
+
+    // Fire-and-forget — do NOT await; analytics must never sit on the gameplay
+    // path. Any failure (network down, bad key) is swallowed silently.
+    void signedFetch({
+      url: `https://${ANALYTICS_CONFIG.host}/i/v0/e/`,
+      init: {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      }
+    }).catch(() => {
+      // swallow — analytics must never break the game
+    })
+  } catch {
+    // swallow — analytics must never break the game
+  }
+}

--- a/src/shared/analyticsConfig.ts
+++ b/src/shared/analyticsConfig.ts
@@ -1,0 +1,23 @@
+/**
+ * PostHog analytics config — shared by client and server.
+ *
+ * `projectApiKey` is a PUBLIC, write-only capture token (starts with `phc_`),
+ * safe to ship in the build. Do NOT put a personal API key here.
+ *
+ * Single source of truth for all analytics config (see shared/analytics.ts).
+ */
+export const ANALYTICS_CONFIG = {
+  // Kill switch — set to false to disable ALL tracking (no other code changes).
+  enabled: true,
+
+  // PostHog Cloud host: 'us.i.posthog.com' (US) or 'eu.i.posthog.com' (EU).
+  // This project is EU Cloud.
+  host: 'eu.i.posthog.com',
+
+  // PostHog project API key (phc_...) — public write-only capture token (project 237538).
+  projectApiKey: 'phc_CpcmxwsHB5HGTscBrk7pDv7Z5BKiMzD7TFA65Xj7UKaR',
+
+  // The `game` property stamped on every event so the games are comparable in
+  // one PostHog project. Confirm the slug you want for this game.
+  gameId: 'towerofmadness'
+}

--- a/src/tutorial.ts
+++ b/src/tutorial.ts
@@ -5,6 +5,7 @@ import {
   Billboard,
   BillboardMode,
   AvatarBase,
+  PlayerIdentityData,
   InputModifier,
   InputAction,
   PointerEventType,
@@ -16,6 +17,7 @@ import { isMobile, getPlatform } from '@dcl/sdk/platform'
 import { movePlayerTo } from '~system/RestrictedActions'
 import { playCinematic } from './cinematicCamera'
 import { onTutorialStatus, sendTutorialCompleted } from './multiplayer'
+import { trackEvent } from './shared/analytics'
 
 // ============================================
 // PIGEON TUTORIAL — guided onboarding
@@ -148,6 +150,18 @@ function despawnPigeon() {
   pigeonEntity = null
 }
 
+// Funnel order for the tutorial — lets PostHog show where players drop off
+// (churn). Index climbs 1..6; DONE = reached the end.
+const TUTORIAL_STEP_INDEX: Record<TutorialStep, number> = {
+  [TutorialStep.INACTIVE]: 0,
+  [TutorialStep.WELCOME]: 1,
+  [TutorialStep.LEARN_MOVE]: 2,
+  [TutorialStep.JUMP_INTRO]: 3,
+  [TutorialStep.GLIDE_TIP]: 4,
+  [TutorialStep.CLIMB]: 5,
+  [TutorialStep.DONE]: 6
+}
+
 function setStep(step: TutorialStep, text: string) {
   tutorialStep = step
   tutorialDialogText = text
@@ -158,6 +172,17 @@ function setStep(step: TutorialStep, text: string) {
   tutorialShowTryButton = false
   tutorialShowGotItButton = false
   tutorialShowSkipButton = false
+
+  // Analytics — one event per tutorial step reached, so PostHog can build a
+  // funnel and show the churn point. INACTIVE isn't a real step.
+  if (step !== TutorialStep.INACTIVE) {
+    const wallet = PlayerIdentityData.getOrNull(engine.PlayerEntity)?.address ?? ''
+    trackEvent('tutorial step reached', wallet, {
+      step,
+      step_index: TUTORIAL_STEP_INDEX[step],
+      is_mobile: isMobile()
+    })
+  }
 }
 
 function beginTutorial(allowSkip: boolean) {
@@ -171,7 +196,11 @@ function beginTutorial(allowSkip: boolean) {
   tutorialShowSkipButton = allowSkip
 }
 
-function finishTutorial() {
+function finishTutorial(skipped: boolean = false) {
+  // Capture where the player was BEFORE we overwrite the step to DONE — that's
+  // the churn point for a skip.
+  const fromStep = tutorialStep
+
   setInputMode({ disableDoubleJump: false, disableGliding: false })
   despawnPigeon()
 
@@ -185,6 +214,16 @@ function finishTutorial() {
   if (!tutorialCompletedSent) {
     tutorialCompletedSent = true
     sendTutorialCompleted()
+
+    // Analytics — terminal outcome, fired exactly once. skip vs complete are
+    // distinct signals that the step funnel can't recover (both paths land here
+    // and DONE is set directly, not via setStep).
+    const wallet = PlayerIdentityData.getOrNull(engine.PlayerEntity)?.address ?? ''
+    trackEvent(skipped ? 'tutorial skipped' : 'tutorial completed', wallet, {
+      from_step: fromStep,
+      from_step_index: TUTORIAL_STEP_INDEX[fromStep],
+      is_mobile: isMobile()
+    })
   }
 
   // The tutorial now runs before the intro cinematic — trigger it here,
@@ -222,7 +261,7 @@ export function onGotItClicked() {
 export function onSkipClicked() {
   if (tutorialStep !== TutorialStep.WELCOME) return
   if (!welcomeSkipAllowed) return
-  finishTutorial()
+  finishTutorial(true)
 }
 
 // Called once, right when the client's state first syncs on arrival — before


### PR DESCRIPTION
in this PR:
PostHog analytics + chunk collider fix

Two changes validated together in playtesting:

1. PostHog analytics — a small, provider-agnostic tracking layer (single trackEvent choke point, fire-and-forget, wallet as identity).

session started (server-side, one per scene entry) → unlocks D1/D7/D30 retention
Tutorial funnel: tutorial step reached + terminal tutorial completed / tutorial skipped → shows where players drop off (mobile onboarding)
Every event carries a game property for multi-game comparison (EU cloud)
2. Chunk collider fix — players were falling through freshly-renewed tower chunks. Root cause: on a cold cache, a chunk's visible mesh renders before its GLB finishes loading, and the collider only becomes active at FINISHED — so players reached the lower chunks before their colliders existed. Fix: preload (warm the cache for) all chunk GLBs at scene start, so tower renewals never hit a cold load.

Files

Analytics: shared/analyticsConfig.ts, shared/analytics.ts, wired into server.ts (session) and tutorial.ts (funnel)
Fix: chunkPreload.ts, wired into the client startup
