### PR TITLE
fix: broken ui's with last sdk update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
       "devDependencies": {
         "@dcl/asset-packs": "latest",
         "@dcl/hammurabi-server": "^1.0.0-21726116521.commit-148f55a",
-        "@dcl/js-runtime": "7.21.1-22918726402.commit-ee210ee",
-        "@dcl/sdk": "^7.26.1-32160793830.commit-0b97733"
+        "@dcl/js-runtime": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/bevy-headless-server/@dcl/js-runtime/dcl-js-runtime-7.26.1-32272684883.commit-03948db.tgz",
+        "@dcl/sdk": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/bevy-headless-server/dcl-sdk-7.26.1-32272684883.commit-03948db.tgz"
       },
       "engines": {
         "node": ">=20.0.0",
@@ -213,9 +213,9 @@
       }
     },
     "node_modules/@dcl/ecs": {
-      "version": "7.26.1-32160793830.commit-0b97733",
-      "resolved": "https://registry.npmjs.org/@dcl/ecs/-/ecs-7.26.1-32160793830.commit-0b97733.tgz",
-      "integrity": "sha512-cEvgVRV0u1s0+gliTw6zeUYag9YWdgkWx5m4A1oV1TYdQRa6yM9EwQQ9tLKfsGp3lsFyS09G/YCAy4sy/FLMwA==",
+      "version": "7.26.1-32272684883.commit-03948db",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/bevy-headless-server/@dcl/ecs/dcl-ecs-7.26.1-32272684883.commit-03948db.tgz",
+      "integrity": "sha512-yS1CWuN7b2Md73rvkBdsVhNA1gT3DBIOk7laXBigP/ya4rWdrZ6ZpcaIf0ZAxrSshmG7ZLBviPRBRaS9E2CFNg==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -323,9 +323,9 @@
       }
     },
     "node_modules/@dcl/inspector/node_modules/@dcl/asset-packs": {
-      "version": "2.17.2",
-      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-2.17.2.tgz",
-      "integrity": "sha512-/YMQEBYkdZCcpPOP58l8fYDduGqtNnO0JYgOwI0RNMZ8MW/Dl902RW5KExhlGBfto+X2BwFH3aY8yAG/qbW2OQ==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@dcl/asset-packs/-/asset-packs-2.18.0.tgz",
+      "integrity": "sha512-kOnooLUBsnhbMPhxUxdarFk/b/wYh8kH3y2VAdzdoQmYg1mUzEgvKQrqR3D5syGwKMF/dvBEDvBGQKyJkpGL7w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -410,9 +410,9 @@
       }
     },
     "node_modules/@dcl/js-runtime": {
-      "version": "7.21.1-22918726402.commit-ee210ee",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.21.1-22918726402.commit-ee210ee.tgz",
-      "integrity": "sha512-Q088hyE1Bm8Wpxx98BRVJYeRlmZ7ty2E/oCX20Xfdo1uGlgSZ5KHLQMuNDDzi9CSwZj8oeUrzJPLq5py+mvMGQ==",
+      "version": "7.26.1-32272684883.commit-03948db",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/bevy-headless-server/@dcl/js-runtime/dcl-js-runtime-7.26.1-32272684883.commit-03948db.tgz",
+      "integrity": "sha512-8sxhKzgFkSd3h0UtbCNvjRik8gSTEkNraJNgSzeImHf9Z4orpDq+BChUmiQwmJMnTj05AAJvaY/7zY8DKP7sfA==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -494,13 +494,13 @@
       "license": "MIT"
     },
     "node_modules/@dcl/react-ecs": {
-      "version": "7.26.1-32160793830.commit-0b97733",
-      "resolved": "https://registry.npmjs.org/@dcl/react-ecs/-/react-ecs-7.26.1-32160793830.commit-0b97733.tgz",
-      "integrity": "sha512-zuq9RkA+k0UrZPcYt2l+iWNZ00sWb02ZmfbDUKM+3KL6a3SxvNv8YrdPa/mgSNJTGs0/05NeFHNCxkgast4Arg==",
+      "version": "7.26.1-32272684883.commit-03948db",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/bevy-headless-server/@dcl/react-ecs/dcl-react-ecs-7.26.1-32272684883.commit-03948db.tgz",
+      "integrity": "sha512-uK5SaIx3Le3ZRIYMT0nPexAnnmvUmhfh0BGkpa4Qe/CcrWf+f1SZpI18rC2+XdFPmmUwwIAnk1pWsHOpPGvgBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/ecs": "7.26.1-32160793830.commit-0b97733",
+        "@dcl/ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/bevy-headless-server/@dcl/ecs/dcl-ecs-7.26.1-32272684883.commit-03948db.tgz",
         "react": "^18.2.0",
         "react-reconciler": "^0.29.0"
       }
@@ -529,29 +529,29 @@
       }
     },
     "node_modules/@dcl/sdk": {
-      "version": "7.26.1-32160793830.commit-0b97733",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk/-/sdk-7.26.1-32160793830.commit-0b97733.tgz",
-      "integrity": "sha512-bxuzUaBugBuTa59KAPUMFG+zngqFEuNKTlJq/EmM+/JQ4KPHOy0jvQ57D4rnFZPP7AT+lz3F2H/21g2Rv/hlBg==",
+      "version": "7.26.1-32272684883.commit-03948db",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/bevy-headless-server/dcl-sdk-7.26.1-32272684883.commit-03948db.tgz",
+      "integrity": "sha512-gxYzz9GuqDP07Dz606nuciyHq8yN7vY9k50n2Yy8KKMGIJwxC7bpjs1WcLHdI4d3n5+liN2163oCV8hBKE9uBg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/ecs": "7.26.1-32160793830.commit-0b97733",
+        "@dcl/ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/bevy-headless-server/@dcl/ecs/dcl-ecs-7.26.1-32272684883.commit-03948db.tgz",
         "@dcl/ecs-math": "2.1.0",
-        "@dcl/js-runtime": "7.26.1-32160793830.commit-0b97733",
-        "@dcl/react-ecs": "7.26.1-32160793830.commit-0b97733",
-        "@dcl/sdk-commands": "7.26.1-32160793830.commit-0b97733"
+        "@dcl/js-runtime": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/bevy-headless-server/@dcl/js-runtime/dcl-js-runtime-7.26.1-32272684883.commit-03948db.tgz",
+        "@dcl/react-ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/bevy-headless-server/@dcl/react-ecs/dcl-react-ecs-7.26.1-32272684883.commit-03948db.tgz",
+        "@dcl/sdk-commands": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/bevy-headless-server/dcl-sdk-commands-7.26.1-32272684883.commit-03948db.tgz"
       }
     },
     "node_modules/@dcl/sdk-commands": {
-      "version": "7.26.1-32160793830.commit-0b97733",
-      "resolved": "https://registry.npmjs.org/@dcl/sdk-commands/-/sdk-commands-7.26.1-32160793830.commit-0b97733.tgz",
-      "integrity": "sha512-zHDtJcirJz6ftXAXSx5T8xheynRyuIHtR6a8cy7ha387lHPotWJ+VM0Mcn10K8bWoOLHUhQ2GfrVkZexKEer+A==",
+      "version": "7.26.1-32272684883.commit-03948db",
+      "resolved": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/bevy-headless-server/dcl-sdk-commands-7.26.1-32272684883.commit-03948db.tgz",
+      "integrity": "sha512-0T9ir8CQjSEksWO4Y3AUuILeOTBxWaPbAWOFiWlOUrL8Lx/AhELixtZ5f7+kJPC2l6u7h/q6/KvbpzpSiLXveQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/crypto": "^3.4.4",
-        "@dcl/ecs": "7.26.1-32160793830.commit-0b97733",
+        "@dcl/ecs": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/bevy-headless-server/@dcl/ecs/dcl-ecs-7.26.1-32272684883.commit-03948db.tgz",
         "@dcl/gltf-validator-ts": "1.0.14",
         "@dcl/hashing": "1.1.3",
         "@dcl/inspector": "7.36.3",
@@ -586,13 +586,6 @@
       "engines": {
         "node": ">=22.0.0"
       }
-    },
-    "node_modules/@dcl/sdk/node_modules/@dcl/js-runtime": {
-      "version": "7.26.1-32160793830.commit-0b97733",
-      "resolved": "https://registry.npmjs.org/@dcl/js-runtime/-/js-runtime-7.26.1-32160793830.commit-0b97733.tgz",
-      "integrity": "sha512-iDZqTPT/cERNBV3ntLMn8ka33A1J3hGRixdIC29oES35Wpj2a8fiiv8TeKI7Yjo9wBKSg/ATwrQQ4XbHySJtdQ==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/@dcl/ts-proto": {
       "version": "1.154.0",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "devDependencies": {
     "@dcl/asset-packs": "latest",
     "@dcl/hammurabi-server": "^1.0.0-21726116521.commit-148f55a",
-    "@dcl/js-runtime": "7.26.1-32160793830.commit-0b97733",
-    "@dcl/sdk": "^7.26.1-32160793830.commit-0b97733"
+    "@dcl/js-runtime": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/bevy-headless-server/@dcl/js-runtime/dcl-js-runtime-7.26.1-32272684883.commit-03948db.tgz",
+    "@dcl/sdk": "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/bevy-headless-server/dcl-sdk-7.26.1-32272684883.commit-03948db.tgz"
   },
   "engines": {
     "node": ">=20.0.0",

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -1,10 +1,44 @@
 import ReactEcs, { UiEntity, ReactEcsRenderer } from "@dcl/sdk/react-ecs"
 import { Color4 } from "@dcl/sdk/math"
 import { engine, UiCanvasInformation, PlayerIdentityData } from "@dcl/sdk/ecs"
+import { isMobile as isMobileFn } from "@dcl/sdk/platform"
 
-// Scaling is handled by the renderer's virtual resolution, so no extra factor is applied here
+let uiRendererSyncRegistered = false
+let lastAppliedUiRendererSignature = ""
+
+function getUiCanvasInfo() {
+  return UiCanvasInformation.getOrNull(engine.RootEntity)
+}
+
+function getUiRendererConfig() {
+  const isMobile = isMobileFn()
+  const virtualWidth = isMobile ? 1600 : 1920
+  const virtualHeightBase = isMobile ? 720 : 1080
+
+  return {
+    virtualWidth,
+    // Keep the mobile virtual size off exact 16:9 so the SDK does not override it back to 1600x720.
+    virtualHeight: isMobile ? virtualHeightBase + 1 : virtualHeightBase,
+    screenInset: "none" as const
+  }
+}
+
+function getUiLayoutSize() {
+  const config = getUiRendererConfig()
+  if (config.virtualWidth > 0 && config.virtualHeight > 0) {
+    return { width: config.virtualWidth, height: config.virtualHeight }
+  }
+
+  const canvasInfo = getUiCanvasInfo()
+  return {
+    width: canvasInfo?.width ?? 1920,
+    height: canvasInfo?.height ?? 1080
+  }
+}
+
 function getScaleUIFactor(): number {
-  return 1
+  const { width } = getUiLayoutSize()
+  return Math.min(1, Math.max(0.1, width / 1920))
 }
 
 import {
@@ -67,10 +101,26 @@ import {
   onGotItClicked,
   onSkipClicked
 } from "./tutorial"
-import { isMobile as isMobileFn } from "@dcl/sdk/platform"
 
 export function setupUi() {
-  ReactEcsRenderer.setUiRenderer(GameUI, { virtualHeight: 0, virtualWidth: 0 })
+  if (!uiRendererSyncRegistered) {
+    uiRendererSyncRegistered = true
+    engine.addSystem(syncUiRendererSystem)
+  }
+  applyUiRenderer(true)
+}
+
+function applyUiRenderer(force: boolean = false): void {
+  const config = getUiRendererConfig()
+  const signature = `${isMobileFn()}:${config.virtualWidth}x${config.virtualHeight}:${config.screenInset}`
+  if (!force && signature === lastAppliedUiRendererSignature) return
+
+  ReactEcsRenderer.setUiRenderer(GameUI, config)
+  lastAppliedUiRendererSignature = signature
+}
+
+function syncUiRendererSystem(): void {
+  applyUiRenderer()
 }
 
 // Chunk colors for tower progress bar
@@ -174,8 +224,7 @@ let _lastReorderLogMs = 0
 // Tower Progress Bar Component
 const TowerProgressBar = () => {
   const s = getScaleUIFactor()
-  const uiCanvasInfo = UiCanvasInformation.getOrNull(engine.RootEntity)
-  const screenWidth = uiCanvasInfo?.width ?? 1920 * s
+  const { width: screenWidth } = getUiLayoutSize()
   const snapshots = getSnapshots()
   const snapshotByWallet = new Map(
     snapshots
@@ -233,7 +282,7 @@ const TowerProgressBar = () => {
         width: BAR_WIDTH,
         height: BAR_HEIGHT,
         positionType: 'absolute',
-        position: { top: isMobileFn() ? 0 : 130 * s, left: (screenWidth - BAR_WIDTH) / 2 + (isMobileFn() ? 80 : 0) },
+        position: { top: 130 * s, left: (screenWidth - BAR_WIDTH) / 2 },
         flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'flex-start'
@@ -1406,9 +1455,7 @@ const GameUI = () => {
   const isMobile = isMobileFn()
   const mobileBoostScale = s * (isMobile ? 3 : 1)
   const startMessageScale = isMobile ? 3 : 1
-  const uiCanvasInfo = UiCanvasInformation.getOrNull(engine.RootEntity)
-  const screenWidth = uiCanvasInfo?.width ?? 1920 * s
-  const screenHeight = uiCanvasInfo?.height ?? 1080 * s
+  const { width: screenWidth, height: screenHeight } = getUiLayoutSize()
   const localPlayerAddress = PlayerIdentityData.getOrNull(engine.PlayerEntity)?.address?.toLowerCase() ?? ''
   const playerInfoWidth = 260 * s
   const startMessageWidth = 260 * s
@@ -1606,7 +1653,7 @@ const GameUI = () => {
           width: '100%',
           height: 100 * s,
           positionType: 'absolute',
-          position: { top: (isMobile ? 35 : 15 * s), left: 0 },
+          position: { top: 15 * s, left: 0 },
           alignItems: 'center',
           justifyContent: 'center'
         }}

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -4,7 +4,7 @@ import { engine, UiCanvasInformation, PlayerIdentityData } from "@dcl/sdk/ecs"
 import { isMobile as isMobileFn } from "@dcl/sdk/platform"
 
 let uiRendererSyncRegistered = false
-let lastAppliedUiRendererSignature = ""
+let lastAppliedUiRendererConfig: { virtualWidth: number; virtualHeight: number; screenInset: "none" } | null = null
 
 function getUiCanvasInfo() {
   return UiCanvasInformation.getOrNull(engine.RootEntity)
@@ -13,32 +13,36 @@ function getUiCanvasInfo() {
 function getUiRendererConfig() {
   const isMobile = isMobileFn()
   const virtualWidth = isMobile ? 1600 : 1920
-  const virtualHeightBase = isMobile ? 720 : 1080
+  const virtualHeight = isMobile ? 720 : 1080
 
   return {
     virtualWidth,
-    // Keep the mobile virtual size off exact 16:9 so the SDK does not override it back to 1600x720.
-    virtualHeight: isMobile ? virtualHeightBase + 1 : virtualHeightBase,
+    virtualHeight,
     screenInset: "none" as const
   }
 }
 
 function getUiLayoutSize() {
+  const canvasInfo = getUiCanvasInfo()
   const config = getUiRendererConfig()
-  if (config.virtualWidth > 0 && config.virtualHeight > 0) {
-    return { width: config.virtualWidth, height: config.virtualHeight }
+  if (canvasInfo && config.virtualWidth > 0 && config.virtualHeight > 0) {
+    const scale = Math.min(canvasInfo.width / config.virtualWidth, canvasInfo.height / config.virtualHeight)
+    if (scale > 0) {
+      return {
+        width: canvasInfo.width / scale,
+        height: canvasInfo.height / scale
+      }
+    }
   }
 
-  const canvasInfo = getUiCanvasInfo()
-  return {
-    width: canvasInfo?.width ?? 1920,
-    height: canvasInfo?.height ?? 1080
-  }
+  if (canvasInfo) return { width: canvasInfo.width, height: canvasInfo.height }
+
+  return { width: config.virtualWidth || 1920, height: config.virtualHeight || 1080 }
 }
 
 function getScaleUIFactor(): number {
-  const { width } = getUiLayoutSize()
-  return Math.min(1, Math.max(0.1, width / 1920))
+  const { virtualWidth } = getUiRendererConfig()
+  return Math.min(1, Math.max(0.1, virtualWidth / 1920))
 }
 
 import {
@@ -112,11 +116,18 @@ export function setupUi() {
 
 function applyUiRenderer(force: boolean = false): void {
   const config = getUiRendererConfig()
-  const signature = `${isMobileFn()}:${config.virtualWidth}x${config.virtualHeight}:${config.screenInset}`
-  if (!force && signature === lastAppliedUiRendererSignature) return
+  if (
+    !force &&
+    lastAppliedUiRendererConfig &&
+    lastAppliedUiRendererConfig.virtualWidth === config.virtualWidth &&
+    lastAppliedUiRendererConfig.virtualHeight === config.virtualHeight &&
+    lastAppliedUiRendererConfig.screenInset === config.screenInset
+  ) {
+    return
+  }
 
   ReactEcsRenderer.setUiRenderer(GameUI, config)
-  lastAppliedUiRendererSignature = signature
+  lastAppliedUiRendererConfig = config
 }
 
 function syncUiRendererSystem(): void {


### PR DESCRIPTION
## Summary

This PR reworks the mobile UI update in Tower of Madness to fully align it with the latest SDK behavior and with the approach already applied in other scenes.

## Changes

- Aligned the scene to the same SDK build used in the other updated projects:
  - `@dcl/sdk` `7.26.1-32272684883.commit-03948db`
  - `@dcl/js-runtime` `7.26.1-32272684883.commit-03948db`
- Updated `package.json`, `package-lock.json`, and local dependencies so the declared and installed SDK versions match.
- Replaced the previous UI renderer setup with a stable mobile virtual screen configuration.
- Added renderer sync logic so the UI config stays consistent with the current device/runtime state.
- Restored UI scaling based on the virtual layout instead of keeping a fixed scale of `1`.
- Removed the temporary mobile positioning adjustments that were compensating for the previous renderer behavior.
- Re-centered the mobile HUD/layout calculations so UI elements no longer drift to the left.

## Why

The previous mobile UI update only partially adapted the scene to the SDK UI changes. It mixed the new SDK behavior with legacy layout assumptions and manual mobile offsets, which caused the HUD and top UI elements to appear misaligned on mobile.

This PR applies the same correction strategy used in the other scenes so the mobile UI uses a consistent virtual layout and predictable scaling.

## Testing

- `npm run build`

Closes #177 
